### PR TITLE
Add support for publishing images to multiple registries

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -24,6 +24,8 @@ jobs:
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          #QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          #QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
         with:
           entrypoint: make
           args: maker-image PUSH=true
@@ -32,6 +34,8 @@ jobs:
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          #QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          #QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
         with:
           entrypoint: make
           args: compilers-image PUSH=true
@@ -40,6 +44,8 @@ jobs:
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          #QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          #QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
         with:
           entrypoint: make
           args: bpftool-image PUSH=true
@@ -48,6 +54,8 @@ jobs:
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          #QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          #QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
         with:
           entrypoint: make
           args: iproute2-image PUSH=true
@@ -56,6 +64,8 @@ jobs:
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          #QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          #QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
         with:
           entrypoint: make
           args: llvm-image PUSH=true

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-REGISTRY_PREFIX ?= docker.io/cilium
+REGISTRIES ?= docker.io/cilium
+# quay.io is not enabled, see https://github.com/cilium/image-tools/issues/11
+# REGISTRIES ?= docker.io/cilium quay.io/cilium
+
 PUSH ?= false
 
 OUTPUT := "type=docker"
@@ -16,25 +19,25 @@ lint:
 
 .buildx_builder:
 	mkdir -p .buildx
-	docker buildx create --platform linux/amd64,linux/arm64 > $@
+	docker buildx create --platform linux/amd64,linux/arm64 --buildkitd-flags '--debug' > $@
 
 maker-image: .buildx_builder
-	scripts/build-image.sh $(REGISTRY_PREFIX)/image-maker images/maker linux/amd64 $(OUTPUT) "$$(cat .buildx_builder)"
+	scripts/build-image.sh image-maker images/maker linux/amd64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
 
 update-maker-image:
-	scripts/update-maker-image.sh $(REGISTRY_PREFIX)
+	scripts/update-maker-image.sh $(firstword $(REGISTRIES))
 
 compilers-image: .buildx_builder
-	scripts/build-image.sh $(REGISTRY_PREFIX)/image-compilers images/compilers linux/amd64 $(OUTPUT) "$$(cat .buildx_builder)"
+	scripts/build-image.sh image-compilers images/compilers linux/amd64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
 
 update-compilers-image:
-	scripts/update-compilers-image.sh $(REGISTRY_PREFIX)
+	scripts/update-compilers-image.sh $(firstword $(REGISTRIES))
 
 bpftool-image: .buildx_builder
-	scripts/build-image.sh $(REGISTRY_PREFIX)/cilium-bpftool images/bpftool linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)"
+	scripts/build-image.sh cilium-bpftool images/bpftool linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
 
 iproute2-image: .buildx_builder
-	scripts/build-image.sh $(REGISTRY_PREFIX)/cilium-iproute2 images/iproute2 linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)"
+	scripts/build-image.sh cilium-iproute2 images/iproute2 linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
 
 llvm-image: .buildx_builder
-	scripts/build-image.sh $(REGISTRY_PREFIX)/cilium-llvm images/llvm linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)"
+	scripts/build-image.sh cilium-llvm images/llvm linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)

--- a/images/maker/build-credentials-helper.sh
+++ b/images/maker/build-credentials-helper.sh
@@ -15,5 +15,5 @@ cd /src
 unset GOPATH
 
 go mod init github.com/cilium/packaging/images/maker
-go get github.com/errordeveloper/docker-credential-env@v0.1.1
+go get github.com/errordeveloper/docker-credential-env@v0.1.4
 go build github.com/errordeveloper/docker-credential-env

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -9,8 +9,8 @@ set -o nounset
 
 MAKER_IMAGE="${MAKER_IMAGE:-docker.io/cilium/image-maker:2831b3fa8bc8a1412ed8eb59b158a123fe0459ef}"
 
-if [ "$#" -ne 5 ] ; then
-  echo "$0 supports exactly 5 argument"
+if [ "$#" -lt 6 ] ; then
+  echo "$0 supports minimum 6 argument"
   exit 1
 fi
 
@@ -25,21 +25,39 @@ platform="${3}"
 output="${4}"
 builder="${5}"
 
+shift 5
+
+registries=("${@}")
+
 image_tag="$("${root_dir}/scripts/make-image-tag.sh" "${image_dir}")"
 
-check_tag_exists() {
+tag_args=()
+for registry in "${registries[@]}" ; do
+  tag_args+=(--tag "${registry}/${image_name}:${image_tag}")
+done
+
+check_image_tag() {
   if [ -n "${MAKER_CONTAINER+x}" ] ; then
-    crane ls "${image_name}" --verbose | grep -q "${image_tag}"
+    crane ls "${1}" 2> /dev/null | grep -q "${2}"
   else
-    # unlike with other utility scripts we don't want to selt-re-exec inside container, as native `docker buildx` is preferred
-    docker run --rm --volume "$(pwd):/src" --workdir /src "${MAKER_IMAGE}" crane ls --verbose "${image_name}" | grep -q "${image_tag}"
+    # unlike with other utility scripts we don't want to self-re-exec inside the container, as native `docker buildx` is preferred
+    docker run --rm --volume "$(pwd):/src" --workdir /src "${MAKER_IMAGE}" crane ls "${1}" 2> /dev/null | grep -q "${2}"
   fi
+}
+
+check_registries() {
+  for registry in "${registries[@]}" ; do
+    if ! check_image_tag "${registry}/${image_name}" "${image_tag}" ; then
+      echo "${registry}/${image_name}:${image_tag} doesn't exist"
+      return 1
+    fi
+  done
 }
 
 do_build="${FORCE:-false}"
 
 if [ "${do_build}" = "true" ] ; then
-  echo "will force-build ${image_name}:${image_tag} without checking the registry"
+  echo "will force-build ${image_name}:${image_tag} without checking the registries"
 fi
 
 if [ "${do_build}" = "false" ] ; then
@@ -53,24 +71,34 @@ if [ "${do_build}" = "false" ] ; then
       do_build="true"
       ;;
     *)
-      if check_tag_exists ; then
-        echo "image ${image_name}:${image_tag} is already present in the registry"
+      if check_registries ; then
+        echo "image ${image_name}:${image_tag} is already present in all of the registries"
         exit 0
       else
-        echo "will build ${image_name}:${image_tag} as it is a new version"
+        echo "will build ${image_name}:${image_tag} as it's either a new version or not present in all of the registries"
         do_build="true"
       fi
       ;;
   esac
 fi
 
-if [ "${do_build}" = "true" ] ; then
-  echo "building ${image_name}:${image_tag}"
-  set -o xtrace
+run_buildx() {
   docker buildx build \
-    --tag "${image_name}:${image_tag}" \
+    "${tag_args[@]}" \
     --platform "${platform}" \
     --output "${output}" \
     --builder "${builder}" \
       "${image_dir}"
+}
+
+if [ "${do_build}" = "true" ] ; then
+  echo "building ${image_name}:${image_tag}"
+  set -o xtrace
+  if ! run_buildx ; then
+    if [ -n "${DEBUG+x}" ] ; then
+      buildkitd_container="$(docker ps --filter "ancestor=moby/buildkit:buildx-stable-1" --filter "name=${builder}" --format "{{.ID}}")"
+      docker logs "${buildkitd_container}"
+      exit 1
+    fi
+  fi
 fi


### PR DESCRIPTION
- handle any number of registies
- force re-build when image is missing in either of the registries
- bump docker-credential-env to ensure quay.io URLs are handled well
- enable buildkitd debug logs
- improve registry check reliability

/xref https://github.com/cilium/image-tools/issues/11