### PR TITLE
docker, bpftool: fix checking out too old bpftool revision

### DIFF
--- a/images/bpftool/checkout-linux.sh
+++ b/images/bpftool/checkout-linux.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-rev="115506fea499f1cd9a80290b31eca4352e0559e9"
+rev="e7b4e85255f2432a7e7d649710959398a1c70892"
 
 # git clone git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git /src/linux
 # cd /src/linux


### PR DESCRIPTION
Commit 61d38f67f109 ("Build images in GitHub Actions (#3)") pointed
bpftool back to an old revision which breaks the expectations from
cilium-runtime. Move it forward in time to something recent.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>