### PR TITLE
Add tester image that includes kubectl, helm, docker and kind

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -38,6 +38,16 @@ jobs:
           entrypoint: make
           args: tester-image PUSH=true
       - uses: docker://docker.io/cilium/image-maker:3e2ea4f151593908c362307a1de22e68610d955c
+        name: Run make kube-test-image
+        env:
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          #QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          #QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+        with:
+          entrypoint: make
+          args: kube-test-image PUSH=true
+      - uses: docker://docker.io/cilium/image-maker:3e2ea4f151593908c362307a1de22e68610d955c
         name: Run make compilers-image
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/kube-test.validate-kind-cluster.sh
+++ b/.github/workflows/kube-test.validate-kind-cluster.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright 2017-2020 Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [ -z "${GITHUB_ACTIONS+x}" ] ; then
+  exit 1
+fi
+
+if [ "$#" -ne 1 ] ; then
+  echo "$0 supports exactly 1 argument"
+fi
+
+kube_version="${1}"
+
+test_script="
+set -o errexit
+set -o pipefail
+set -o nounset
+
+kind create cluster \
+  --config /etc/kind/${kube_version}/standard-github-actions-cluster.yaml \
+  --kubeconfig /github/workspace/kubeconfig
+
+kubectl get nodes --kubeconfig /github/workspace/kubeconfig --context kind-kind --output wide
+kubectl apply --kubeconfig /github/workspace/kubeconfig --context kind-kind --filename https://raw.github.com/cilium/cilium/v1.8.0/install/kubernetes/quick-install.yaml
+kubectl wait nodes --kubeconfig /github/workspace/kubeconfig --context kind-kind --for=condition=Ready --all --timeout=5m
+"
+
+image="local/kube-test:$(./scripts/make-image-tag.sh images/kube-test)"
+docker load --input artifacts/kube-test.oci
+
+exec docker run \
+    --rm \
+    --env GITHUB_ACTIONS \
+    --env TEST_CONTAINER=true \
+    --volume "/var/run/docker.sock:/var/run/docker.sock" \
+    --volume "/home/runner/work/_temp/_github_home:/github/home" \
+    --volume "/home/runner/work/_temp/_github_workflow:/github/workflow" \
+    --workdir "/github/workspace" \
+      "${image}" \
+      bash -c "${test_script}"

--- a/.github/workflows/kube-test.yaml
+++ b/.github/workflows/kube-test.yaml
@@ -1,0 +1,39 @@
+name: Validate kube-test image
+on: [pull_request,push]
+
+jobs:
+  build-kube-test-image:
+    name: Build new kube-test image
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: docker://docker.io/cilium/image-maker:3e2ea4f151593908c362307a1de22e68610d955c
+        name: Run make kube-test-image
+        env:
+          DOCKER_HUB_PUBLIC_ACCESS_ONLY: "true"
+          QUAY_PUBLIC_ACCESS_ONLY: "true"
+        with:
+          entrypoint: make
+          args: kube-test-image REGISTRIES=local EXPORT=true
+      - name: Store OCI image artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: kube-test.oci
+          path: kube-test.oci
+
+  kind:
+    needs: build-kube-test-image
+    strategy:
+      matrix:
+        kube_version: [1.16, 1.17, 1.18]
+    name: Test newly built kube-test image
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Restore OCI image artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: kube-test.oci
+          path: artifacts
+      - name: Load the image and create kind cluster, check it works
+        run: .github/workflows/kube-test.validate-kind-cluster.sh "${{ matrix.kube_version }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .buildx_builder
 .buildx
+*.oci

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,7 @@ REGISTRIES ?= docker.io/cilium
 # REGISTRIES ?= docker.io/cilium quay.io/cilium
 
 PUSH ?= false
-
-OUTPUT := "type=image"
-ifeq ($(PUSH),true)
-OUTPUT := "type=registry,push=true"
-endif
+EXPORT ?= false
 
 all-images: lint maker-image update-maker-image tester-image update-tester-image compilers-image update-compilers-image bpftool-image iproute2-image llvm-image
 
@@ -29,34 +25,37 @@ update-golang-image:
 	scripts/update-golang-image.sh
 
 maker-image: .buildx_builder
-	scripts/build-image.sh image-maker images/maker linux/amd64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
+	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh image-maker images/maker linux/amd64 "$$(cat .buildx_builder)" $(REGISTRIES)
+
+kube-test-image: .buildx_builder
+	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh kube-test images/kube-test linux/amd64 "$$(cat .buildx_builder)" $(REGISTRIES)
 
 update-maker-image:
 	scripts/update-maker-image.sh $(firstword $(REGISTRIES))
 
 tester-image: .buildx_builder
-	TEST=true scripts/build-image.sh image-tester images/tester linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
+	PUSH=$(PUSH) EXPORT=$(EXPORT) TEST=true scripts/build-image.sh image-tester images/tester linux/amd64,linux/arm64 "$$(cat .buildx_builder)" $(REGISTRIES)
 
 update-tester-image:
 	scripts/update-tester-image.sh $(firstword $(REGISTRIES))
 
 compilers-image: .buildx_builder
-	TEST=true scripts/build-image.sh image-compilers images/compilers linux/amd64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
+	PUSH=$(PUSH) EXPORT=$(EXPORT) TEST=true scripts/build-image.sh image-compilers images/compilers linux/amd64 "$$(cat .buildx_builder)" $(REGISTRIES)
 
 update-compilers-image:
 	scripts/update-compilers-image.sh $(firstword $(REGISTRIES))
 
 bpftool-image: .buildx_builder
-	TEST=true scripts/build-image.sh cilium-bpftool images/bpftool linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
+	PUSH=$(PUSH) EXPORT=$(EXPORT) TEST=true scripts/build-image.sh cilium-bpftool images/bpftool linux/amd64,linux/arm64 "$$(cat .buildx_builder)" $(REGISTRIES)
 
 iproute2-image: .buildx_builder
-	TEST=true scripts/build-image.sh cilium-iproute2 images/iproute2 linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
+	PUSH=$(PUSH) EXPORT=$(EXPORT) TEST=true scripts/build-image.sh cilium-iproute2 images/iproute2 linux/amd64,linux/arm64 "$$(cat .buildx_builder)" $(REGISTRIES)
 
 llvm-image: .buildx_builder
-	TEST=true scripts/build-image.sh cilium-llvm images/llvm linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
+	PUSH=$(PUSH) EXPORT=$(EXPORT) TEST=true scripts/build-image.sh cilium-llvm images/llvm linux/amd64,linux/arm64 "$$(cat .buildx_builder)" $(REGISTRIES)
 
 ca-certificates-image: .buildx_builder
-	scripts/build-image.sh ca-certificates images/ca-certificates linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
+	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh ca-certificates images/ca-certificates linux/amd64,linux/arm64 "$$(cat .buildx_builder)" $(REGISTRIES)
 
 startup-script-image: .buildx_builder
-	scripts/build-image.sh startup-script images/startup-script linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
+	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh startup-script images/startup-script linux/amd64,linux/arm64 "$$(cat .buildx_builder)" $(REGISTRIES)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Since `buildx` runs a BuildKit daemon inside a container, it's largely independe
 This image also includes a secure credentials helper - [`docker-credential-env`](http://github.com/errordeveloper/docker-credential-env),
 which prevents having to use `docker login` which stores a plain text token in `${DOCKER_CONFIG}/config.json`.
 
+### [`images/kube-test`](images/kube-test/Dockerfile)
+
+This image primarily provides `kubectl`, `helm`, `docker` and `kind`. The image is structurally similar to `maker`, and it also
+include `docker`, however the purpose is different and it is important to keep the size of `maker` relatively small.
+Also, it's unlikely that `maker` image will be updated as often as the `kube-test`.
+
 ### [`images/compiler`](images/compilers/Dockerfile)
 
 This image consists of compilers and libraries needed to build other images for `amd64` and `arm64`.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ This repository contains build definitions for a number of images that are compo
 
 The builds are currently hosted in GitHub Actions, but can be ported to any other container-based CI system.
 
+Portability between CI systems and ability to run localy is critical, that's why some of these images are perfered over pre-packaged GitHub Actions.
+Also, pre-package action often download dependencies on-the-fly, potentially increasing build times and causing flakiness. Registry is a network
+resource, which could be unreliable at times, hower it can be mirrored easily, unlike GitHub releases.
+Some of the image do depend on GitHub releases or other HTTP blol storage providers, but there is no easy way around that, as the only alrearnative
+would be to build all of the dependencies from source, which is not feasible.
+
 ## Images
 
 ### [`images/maker`](images/maker/Dockerfile)

--- a/images/kube-test/.dockerignore
+++ b/images/kube-test/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/images/kube-test/Dockerfile
+++ b/images/kube-test/Dockerfile
@@ -1,0 +1,57 @@
+# Copyright 2020 Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+ARG DOCKER_IMAGE=docker:19.03.8-dind@sha256:841b5eb000551dc3c30a46386ab4bfed5839ec9592c88e961236b25194ce88b9
+ARG ALPINE_BASE_IMAGE=alpine:3.11.6@sha256:9a839e63dad54c3a6d1834e29692c8492d93f90c59c978c1ed79109ea4fb9a54
+
+FROM ${DOCKER_IMAGE} as docker-dist
+
+FROM ${ALPINE_BASE_IMAGE} as builder
+
+RUN apk add --no-cache \
+    bash \
+    curl \
+    && true
+
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+
+RUN apk add --initdb --no-cache --root /out \
+    alpine-baselayout \
+    bash \
+    ca-certificates \
+    coreutils \
+    git \
+    make \
+    && true
+
+COPY --from=docker-dist /usr/local/bin /out/usr/local/bin
+
+ARG KIND_VERSION=0.8.1
+
+RUN curl --fail --show-error --silent --location \
+      https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64 \
+    --output /out/usr/local/bin/kind \
+    && chmod +x /out/usr/local/bin/kind
+
+ARG KUBECTL_VERSION=1.18.3
+
+RUN curl --fail --show-error --silent --location \
+      https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
+    --output /out/usr/local/bin/kubectl \
+    && chmod +x /out/usr/local/bin/kubectl
+
+ARG HELM_VERSION=3.2.1
+
+RUN curl --fail --show-error --silent --location \
+     https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
+   --output /tmp/helm.tgz \
+   && tar -xf /tmp/helm.tgz linux-amd64/helm -C /tmp \
+   && mv /tmp/linux-amd64/helm /out/usr/local/bin  \
+   && rm -rf /tmp/helm.tgz /tmp/linux-amd64
+
+COPY configure.sh /tmp/configure.sh
+RUN /tmp/configure.sh
+
+FROM scratch
+ENV TESTER_CONTAINER=true
+COPY --from=builder /out /

--- a/images/kube-test/configure.sh
+++ b/images/kube-test/configure.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright 2017-2020 Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# source - release note: https://github.com/kubernetes-sigs/kind/releases/tag/v0.8.0
+# TODO: automate upgrades
+
+declare -A node_images
+
+node_images["1.18"]="kindest/node:v1.18.2@sha256:7b27a6d0f2517ff88ba444025beae41491b016bc6af573ba467b70c5e8e0d85f"
+node_images["1.17"]="kindest/node:v1.17.5@sha256:ab3f9e6ec5ad8840eeb1f76c89bb7948c77bbf76bcebe1a8b59790b8ae9a283a"
+node_images["1.16"]="kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765"
+node_images["1.15"]="kindest/node:v1.15.11@sha256:6cc31f3533deb138792db2c7d1ffc36f7456a06f1db5556ad3b6927641016f50"
+node_images["1.14"]="kindest/node:v1.14.10@sha256:6cd43ff41ae9f02bb46c8f455d5323819aec858b99534a290517ebc181b443c6"
+node_images["1.13"]="kindest/node:v1.13.12@sha256:214476f1514e47fe3f6f54d0f9e24cfb1e4cda449529791286c7161b7f9c08e7"
+node_images["1.12"]="kindest/node:v1.12.10@sha256:faeb82453af2f9373447bb63f50bae02b8020968e0889c7fa308e19b348916cb"
+
+docker_bridge_addr="172.17.0.1"
+port="6443"
+
+for kube_version in "${!node_images[@]}" ; do
+mkdir -p "/out/etc/kind/${kube_version}"
+cat > "/out/etc/kind/${kube_version}/standard-github-actions-cluster.yaml" << EOF
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+networking: # docs: https://kind.sigs.k8s.io/docs/user/configuration/#networking
+  # In order for the API to be accessible from any container, Docker bridge IP is used.
+  # This is specific to GitHub Actions environment, elsewhere a different address will
+  # need to be used.
+  apiServerAddress: "${docker_bridge_addr}"
+  # Port allocation doesn't work with the Docker bridge IP, so a static port is used.
+  apiServerPort: ${port}
+  # This is required as Cilium will be used
+  disableDefaultCNI: true
+nodes:
+- role: control-plane
+  image: "${node_images[${kube_version}]}"
+EOF
+done


### PR DESCRIPTION
This is image is similar to maker image, but for now it's preferred to not bloat maker image, but there may be good reasons for consolidation in the future.

The motivation to have a kind image of our own is to make CI implementation more portable, i.e. avoid using community GitHub actions. One benefit is that developers can run exactly the same container images locally, but another is that in the future CI can be moved to another platform as it has moved in the past. This PR updates documentation to include a section covering portability in more detail.