### PR TITLE
llvm: Fix configuration of the AArch64 build

### DIFF
--- a/images/llvm/build-llvm-cross-aarch64.sh
+++ b/images/llvm/build-llvm-cross-aarch64.sh
@@ -21,12 +21,9 @@ CC="${triplet}-gcc" CXX="${triplet}-g++" \
     -DBUILD_SHARED_LIBS="OFF" \
     -DCMAKE_BUILD_TYPE="Release" \
     -DLLVM_BUILD_RUNTIME="OFF" \
-    -DCMAKE_CROSSCOMPILING="True" \
     -DLLVM_TABLEGEN="/src/llvm/llvm/build-native/bin/llvm-tblgen" \
     -DCLANG_TABLEGEN="/src/llvm/llvm/build-native/bin/clang-tblgen" \
-    -DLLVM_TARGET_ARCH="AArch64" \
-    -DLLVM_TARGETS_TO_BUILD="AArch64" \
-    -DLLVM_DEFAULT_TARGET_TRIPLE="${triplet}"
+    -DCMAKE_CROSSCOMPILING="True"
 
 ninja clang llc
 


### PR DESCRIPTION
BPF bytecode is the target, it is independent of CPU architecture.
The configuration was originally overlooked in #3.