### PR TITLE
scripts: Fix a bug in script path, use `${script_dir}` consistently

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -20,6 +20,8 @@ root_dir="$(git rev-parse --show-toplevel)"
 
 cd "${root_dir}"
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 image_name="${1}"
 image_dir="${2}"
 
@@ -32,9 +34,9 @@ shift 5
 registries=("${@}")
 
 if [ "${with_root_context}" = "false" ] ; then
-  image_tag="$("${root_dir}/images/scripts/make-image-tag.sh" "${image_dir}")"
+  image_tag="$("${script_dir}/make-image-tag.sh" "${image_dir}")"
 else
-  image_tag="$("${root_dir}/images/scripts/make-image-tag.sh")"
+  image_tag="$("${script_dir}/make-image-tag.sh")"
 fi
 
 tag_args=()

--- a/scripts/update-alpine-base-image.sh
+++ b/scripts/update-alpine-base-image.sh
@@ -17,9 +17,11 @@ root_dir="$(git rev-parse --show-toplevel)"
 
 cd "${root_dir}"
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 image="${1:-alpine:3.11}"
 
-image_digest="$("${root_dir}/scripts/get-image-digest.sh" "${image}")"
+image_digest="$("${script_dir}/get-image-digest.sh" "${image}")"
 
 # shellcheck disable=SC2207
 used_by=($(git grep -l ALPINE_BASE_IMAGE= images))

--- a/scripts/update-compilers-image.sh
+++ b/scripts/update-compilers-image.sh
@@ -17,11 +17,13 @@ root_dir="$(git rev-parse --show-toplevel)"
 
 cd "${root_dir}"
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 image_name="${1}/image-compilers"
 
-image_tag="$(WITHOUT_SUFFIX=1 "${root_dir}/scripts/make-image-tag.sh" images/compilers)"
+image_tag="$(WITHOUT_SUFFIX=1 "${script_dir}/make-image-tag.sh" images/compilers)"
 
-image_digest="$("${root_dir}/scripts/get-image-digest.sh" "${image_name}:${image_tag}")"
+image_digest="$("${script_dir}/get-image-digest.sh" "${image_name}:${image_tag}")"
 
 # shellcheck disable=SC2207
 used_by=($(git grep -l COMPILERS_IMAGE= images))

--- a/scripts/update-maker-image.sh
+++ b/scripts/update-maker-image.sh
@@ -17,9 +17,11 @@ root_dir="$(git rev-parse --show-toplevel)"
 
 cd "${root_dir}"
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 image_name="${1}/image-maker"
 
-image_tag="$(WITHOUT_SUFFIX=1 "${root_dir}/scripts/make-image-tag.sh" images/maker)"
+image_tag="$(WITHOUT_SUFFIX=1 "${script_dir}/make-image-tag.sh" images/maker)"
 
 # shellcheck disable=SC2207
 used_by_workflows=($(git grep -l "docker://${image_name}:" .github/workflows))
@@ -29,7 +31,7 @@ for i in "${used_by_workflows[@]}" ; do
 done
 
 # shellcheck disable=SC2207
-used_by_scripts=($(git grep -l  "MAKER_IMAGE=\"\${MAKER_IMAGE:-${image_name}:" scripts))
+used_by_scripts=($(git grep -l  "MAKER_IMAGE=\"\${MAKER_IMAGE:-${image_name}:" "${script_dir}"))
 
 for i in "${used_by_scripts[@]}" ; do
   sed "s|\(MAKER_IMAGE=\"\${MAKER_IMAGE:-${image_name}\):.*\(}\"\)\$|\1:${image_tag}\2|" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}" && chmod +x "${i}"


### PR DESCRIPTION
This failed here https://github.com/cilium/image-tools/runs/772247032?check_suite_focus=true.

We should have a way of testing some of this logic before merging, I opened https://github.com/cilium/image-tools/issues/38.