### PR TITLE
scripts: Determine `script_dir` prior to firs `cd`

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -16,11 +16,11 @@ if [ "$#" -lt 6 ] ; then
   exit 1
 fi
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 root_dir="$(git rev-parse --show-toplevel)"
 
 cd "${root_dir}"
-
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 image_name="${1}"
 image_dir="${2}"

--- a/scripts/update-alpine-base-image.sh
+++ b/scripts/update-alpine-base-image.sh
@@ -13,11 +13,11 @@ if [ "$#" -gt 1 ] ; then
   exit 1
 fi
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 root_dir="$(git rev-parse --show-toplevel)"
 
 cd "${root_dir}"
-
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 image="${1:-alpine:3.11}"
 

--- a/scripts/update-compilers-image.sh
+++ b/scripts/update-compilers-image.sh
@@ -13,11 +13,11 @@ if [ "$#" -ne 1 ] ; then
   exit 1
 fi
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 root_dir="$(git rev-parse --show-toplevel)"
 
 cd "${root_dir}"
-
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 image_name="${1}/image-compilers"
 

--- a/scripts/update-maker-image.sh
+++ b/scripts/update-maker-image.sh
@@ -13,11 +13,11 @@ if [ "$#" -ne 1 ] ; then
   exit 1
 fi
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 root_dir="$(git rev-parse --show-toplevel)"
 
 cd "${root_dir}"
-
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 image_name="${1}/image-maker"
 


### PR DESCRIPTION
Works in this repo, but doesn't work when copied under a different path in Cilium repo.