### PR TITLE
Add test to bpftool, iproute2 & llvm images

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,8 +1,13 @@
 ignored:
 # it cannot parse `FROM ${BASE_IMAGE}`
 - DL3006
-# alpine doesn't keep old versions around, so we cannot rely on package pinning
+# alpine doesn't keep old versions around, so we cannot rely on package pinning,
+# which is also very tedious and is deemed uncessary
 - DL3018
+# also disable pining checks for ubuntu, as it currently deemed uncessary and,
+# in most cases, packages are installed via scripts and those don't get checked
+# (albeit, ubuntu repos tend to keep old versions around)
+- DL3008
 # this one just needs to be set, but since `FROM ${BASE_IMAGE}` cannot be parse,
 # there isn't a way to leverage this feature anyway
 allowedRegistries: []

--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,13 @@ update-compilers-image:
 	scripts/update-compilers-image.sh $(firstword $(REGISTRIES))
 
 bpftool-image: .buildx_builder
-	scripts/build-image.sh cilium-bpftool images/bpftool linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
+	TEST=true scripts/build-image.sh cilium-bpftool images/bpftool linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
 
 iproute2-image: .buildx_builder
-	scripts/build-image.sh cilium-iproute2 images/iproute2 linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
+	TEST=true scripts/build-image.sh cilium-iproute2 images/iproute2 linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
 
 llvm-image: .buildx_builder
-	scripts/build-image.sh cilium-llvm images/llvm linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
+	TEST=true scripts/build-image.sh cilium-llvm images/llvm linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
 
 ca-certificates-image: .buildx_builder
 	scripts/build-image.sh ca-certificates images/ca-certificates linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)

--- a/images/bpftool/Dockerfile
+++ b/images/bpftool/Dockerfile
@@ -1,7 +1,11 @@
+# syntax=docker/dockerfile:1.1-experimental
+
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG COMPILERS_IMAGE=docker.io/cilium/image-compilers:818f48aa3eada1d23018f02f3c43a169c51eea1a@sha256:2f71fc0c9bdbb9a430ccb8cd86cb1fecc63acff464fc253fe3cd3748488e0e65
+ARG COMPILERS_IMAGE=docker.io/cilium/image-compilers:b89d4f0224e0886d523d2620268d1ff32631be5a@sha256:369679f60037ca75702bf9f7035fe90b146f1329435e5a38092dffb9fbaf401a
+ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:8bce67040cd0ae39e0beb55bcb976a824d9966d2ac8d2e4bf6119b45505cee64
+ARG TESTER_IMAGE=docker.io/cilium/image-tester:70724309b859786e0a347605e407c5261f316eb0@sha256:89cc1f577d995021387871d3dbeb771b75ab4d70073d9bcbc42e532792719781
 
 FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder
 
@@ -14,7 +18,22 @@ RUN /tmp/build-bpftool-native.sh
 COPY build-bpftool-cross-aarch64.sh /tmp/build-bpftool-cross-aarch64.sh
 RUN /tmp/build-bpftool-cross-aarch64.sh
 
+FROM ${UBUNTU_IMAGE} as rootfs
+ARG TARGETPLATFORM
+
+# hadolint ignore=SC2215
+RUN --mount=type=tmpfs,target=/var/cache/apt --mount=type=tmpfs,target=/var/lib/apt \
+  apt-get update \
+    && apt-get install -y --no-install-recommends libelf1 \
+    && apt-get purge --auto-remove -y
+
+COPY --from=builder /out/${TARGETPLATFORM}/bin /usr/local/bin
+COPY test /test/bpftool
+
+FROM ${TESTER_IMAGE} as test
+COPY --from=rootfs / /
+RUN /test/bin/cst -C /test/bpftool
+
 FROM scratch
 LABEL maintainer="maintainer@cilium.io"
-ARG TARGETPLATFORM
-COPY --from=builder /out/${TARGETPLATFORM}/bin /bin
+COPY --from=rootfs / /

--- a/images/bpftool/checkout-linux.sh
+++ b/images/bpftool/checkout-linux.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-rev="e7b4e85255f2432a7e7d649710959398a1c70892"
+rev="69119673bd50b176ded34032fadd41530fb5af21"
 
 # git clone git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git /src/linux
 # cd /src/linux

--- a/images/bpftool/test/spec.yaml
+++ b/images/bpftool/test/spec.yaml
@@ -1,0 +1,18 @@
+schemaVersion: "2.0.0"
+
+fileExistenceTests:
+- name: '/usr/local/bin/bpftool'
+  path: '/usr/local/bin/bpftool'
+  shouldExist: true
+  permissions: '-rwxr-xr-x'
+
+commandTests:
+- name: "bpftool command is in path"
+  command: "which"
+  args: ["bpftool"]
+  expectedOutput: ["/usr/local/bin/bpftool"]
+- name: "bpftool version"
+  command: "bpftool"
+  args: ["version"]
+  expectedOutput:
+  - 'bpftool\ v5\.8\.0-rc1'

--- a/images/compilers/Dockerfile
+++ b/images/compilers/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:8bce67040cd0ae39e0beb55bcb976a824d9966d2ac8d2e4bf6119b45505cee64
-ARG TESTER_IMAGE=docker.io/cilium/image-tester:a99a94da5d1c0ff1c0c2411f32e25219553a9c9f@sha256:cb808315bc067e9e2e5f12bd7ab589a029eba35eff227ac0f332a2e0ad46738a
+ARG TESTER_IMAGE=docker.io/cilium/image-tester:70724309b859786e0a347605e407c5261f316eb0@sha256:89cc1f577d995021387871d3dbeb771b75ab4d70073d9bcbc42e532792719781
 
 FROM ${UBUNTU_IMAGE} as builder
 

--- a/images/iproute2/Dockerfile
+++ b/images/iproute2/Dockerfile
@@ -1,7 +1,11 @@
+# syntax=docker/dockerfile:1.1-experimental
+
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG COMPILERS_IMAGE=docker.io/cilium/image-compilers:818f48aa3eada1d23018f02f3c43a169c51eea1a@sha256:2f71fc0c9bdbb9a430ccb8cd86cb1fecc63acff464fc253fe3cd3748488e0e65
+ARG COMPILERS_IMAGE=docker.io/cilium/image-compilers:b89d4f0224e0886d523d2620268d1ff32631be5a@sha256:369679f60037ca75702bf9f7035fe90b146f1329435e5a38092dffb9fbaf401a
+ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:8bce67040cd0ae39e0beb55bcb976a824d9966d2ac8d2e4bf6119b45505cee64
+ARG TESTER_IMAGE=docker.io/cilium/image-tester:70724309b859786e0a347605e407c5261f316eb0@sha256:89cc1f577d995021387871d3dbeb771b75ab4d70073d9bcbc42e532792719781
 
 FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder
 
@@ -14,7 +18,22 @@ RUN /tmp/build-iproute2-native.sh
 COPY build-iproute2-cross-aarch64.sh /tmp/build-iproute2-cross-aarch64.sh
 RUN /tmp/build-iproute2-cross-aarch64.sh
 
+FROM ${UBUNTU_IMAGE} as rootfs
+ARG TARGETPLATFORM
+
+# hadolint ignore=SC2215
+RUN --mount=type=tmpfs,target=/var/cache/apt --mount=type=tmpfs,target=/var/lib/apt \
+  apt-get update \
+    && apt-get install -y --no-install-recommends libelf1 libmnl0 \
+    && apt-get purge --auto-remove -y
+
+COPY --from=builder /out/${TARGETPLATFORM}/bin /usr/local/bin
+COPY test /test/iproute2
+
+FROM ${TESTER_IMAGE} as test
+COPY --from=rootfs / /
+RUN /test/bin/cst -C /test/iproute2
+
 FROM scratch
 LABEL maintainer="maintainer@cilium.io"
-ARG TARGETPLATFORM
-COPY --from=builder /out/${TARGETPLATFORM}/bin /bin
+COPY --from=rootfs / /

--- a/images/iproute2/test/spec.yaml
+++ b/images/iproute2/test/spec.yaml
@@ -1,0 +1,45 @@
+schemaVersion: "2.0.0"
+
+fileExistenceTests:
+- name: '/usr/local/bin/ip'
+  path: '/usr/local/bin/ip'
+  shouldExist: true
+  permissions: '-rwxr-xr-x'
+- name: '/usr/local/bin/tc'
+  path: '/usr/local/bin/tc'
+  shouldExist: true
+  permissions: '-rwxr-xr-x'
+- name: '/usr/local/bin/ss'
+  path: '/usr/local/bin/ss'
+  shouldExist: true
+  permissions: '-rwxr-xr-x'
+
+commandTests:
+- name: "ip command is in path"
+  command: "which"
+  args: ["ip"]
+  expectedOutput: ["/usr/local/bin/ip"]
+- name: "tc command is in path"
+  command: "which"
+  args: ["tc"]
+  expectedOutput: ["/usr/local/bin/tc"]
+- name: "ss command is in path"
+  command: "which"
+  args: ["ss"]
+  expectedOutput: ["/usr/local/bin/ss"]
+
+- name: "ip -V"
+  command: "ip"
+  args: ["-V"]
+  expectedOutput:
+  - 'ip\ utility,\ iproute2-ss190107'
+- name: "tc -V"
+  command: "tc"
+  args: ["-V"]
+  expectedOutput:
+  - 'tc\ utility,\ iproute2-ss190107'
+- name: "ss -V"
+  command: "ss"
+  args: ["-V"]
+  expectedOutput:
+  - 'ss\ utility,\ iproute2-ss190107'

--- a/images/llvm/Dockerfile
+++ b/images/llvm/Dockerfile
@@ -1,7 +1,9 @@
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG COMPILERS_IMAGE=docker.io/cilium/image-compilers:818f48aa3eada1d23018f02f3c43a169c51eea1a@sha256:2f71fc0c9bdbb9a430ccb8cd86cb1fecc63acff464fc253fe3cd3748488e0e65
+ARG COMPILERS_IMAGE=docker.io/cilium/image-compilers:b89d4f0224e0886d523d2620268d1ff32631be5a@sha256:369679f60037ca75702bf9f7035fe90b146f1329435e5a38092dffb9fbaf401a
+ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:8bce67040cd0ae39e0beb55bcb976a824d9966d2ac8d2e4bf6119b45505cee64
+ARG TESTER_IMAGE=docker.io/cilium/image-tester:70724309b859786e0a347605e407c5261f316eb0@sha256:89cc1f577d995021387871d3dbeb771b75ab4d70073d9bcbc42e532792719781
 
 FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder
 
@@ -14,7 +16,16 @@ RUN /tmp/build-llvm-native.sh
 COPY build-llvm-cross-aarch64.sh /tmp/build-llvm-cross-aarch64.sh
 RUN /tmp/build-llvm-cross-aarch64.sh
 
+FROM ${UBUNTU_IMAGE} as rootfs
+ARG TARGETPLATFORM
+
+COPY --from=builder /out/${TARGETPLATFORM}/bin /usr/local/bin
+COPY test /test/llvm
+
+FROM ${TESTER_IMAGE} as test
+COPY --from=rootfs / /
+RUN /test/bin/cst -C /test/llvm
+
 FROM scratch
 LABEL maintainer="maintainer@cilium.io"
-ARG TARGETPLATFORM
-COPY --from=builder /out/${TARGETPLATFORM}/bin /bin
+COPY --from=rootfs / /

--- a/images/llvm/build-llvm-cross-aarch64.sh
+++ b/images/llvm/build-llvm-cross-aarch64.sh
@@ -23,7 +23,8 @@ CC="${triplet}-gcc" CXX="${triplet}-g++" \
     -DLLVM_BUILD_RUNTIME="OFF" \
     -DLLVM_TABLEGEN="/src/llvm/llvm/build-native/bin/llvm-tblgen" \
     -DCLANG_TABLEGEN="/src/llvm/llvm/build-native/bin/clang-tblgen" \
-    -DCMAKE_CROSSCOMPILING="True"
+    -DCMAKE_CROSSCOMPILING="True" \
+    -DCMAKE_INSTALL_PREFIX="/usr/local"
 
 ninja clang llc
 

--- a/images/llvm/build-llvm-native.sh
+++ b/images/llvm/build-llvm-native.sh
@@ -17,7 +17,8 @@ cmake .. -G "Ninja" \
   -DLLVM_ENABLE_PROJECTS="clang" \
   -DBUILD_SHARED_LIBS="OFF" \
   -DCMAKE_BUILD_TYPE="Release" \
-  -DLLVM_BUILD_RUNTIME="OFF"
+  -DLLVM_BUILD_RUNTIME="OFF" \
+  -DCMAKE_INSTALL_PREFIX="/usr/local"
 
 ninja clang llc
 

--- a/images/llvm/test/spec.yaml
+++ b/images/llvm/test/spec.yaml
@@ -1,0 +1,32 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+- name: "llc command is in path"
+  command: "which"
+  args: ["llc"]
+  expectedOutput: ["/usr/local/bin/llc"]
+- name: "llc --version"
+  command: "llc"
+  args: ["--version"]
+  expectedOutput:
+  - 'LLVM\ \(http://llvm\.org/\):'
+  - 'LLVM\ version\ 10\.0\.0'
+  - 'Optimized\ build\.'
+  - 'Registered\ Targets:'
+  - '(bpf|bpfeb|bpfel)[\ ]+-\ BPF\ \((host|big|little)\ endian\)'
+  excludedOutput:
+  - '(aarch64|arm|misp|ppc|risc|sparc|thumb|wasm|x86).*\[\ ]+-\ .*'
+- name: "clang command is in path"
+  command: "which"
+  args: ["clang"]
+  expectedOutput: ["/usr/local/bin/clang"]
+- name: "clang --version"
+  command: "clang"
+  args: ["--version"]
+  expectedOutput:
+  - 'clang\ version\ 10\.0\.0\ \(https://github.com/llvm/llvm-project.git\ .*\)'
+  - 'InstalledDir:\ /usr/local/bin'
+
+- name: "clang can compile a simple BPF program"
+  command: "clang"
+  args: [ "-O2", "-target", "bpf", "-c", "test.c", "-o", "/tmp/test.o" ]

--- a/images/llvm/test/test.c
+++ b/images/llvm/test/test.c
@@ -1,0 +1,1 @@
+int main() { return 0; }


### PR DESCRIPTION
- use latest tester image
- update bpftool since commit used previously
  is now missing from bpf-next tree
- ensure final images have system dependencies
- copy test spec into final image, so downstream
  builds can run the test to verify resulting
  images pass the tests
- move output files under `/usr/local/bin`

Fixes: #5