### PR TITLE
compilers: Add Bazel 3.3.1 and 3.4.1 versions

### DIFF
--- a/images/compilers/install-bazel.sh
+++ b/images/compilers/install-bazel.sh
@@ -13,6 +13,8 @@ bazel_versions=(
   "2.2.0"
   "3.1.0"
   "3.2.0"
+  "3.3.1"
+  "3.4.1"
 )
 
 # install bazel wrapper script in the path, it automatically recognises `.bazelversion` and `USE_BAZEL_VERSIONS`, if neither are set it picks latest

--- a/images/compilers/test/spec.yaml
+++ b/images/compilers/test/spec.yaml
@@ -78,10 +78,38 @@ commandTests:
   args: ["version"]
   expectedOutput: ['Build\ label:\ 3\.2\.0']
 
+- name: "which bazel-3.3.1-linux-x86_64"
+  command: "which"
+  args: ["bazel-3.3.1-linux-x86_64"]
+  expectedOutput: ["/usr/local/bin/bazel-3.3.1-linux-x86_64"]
+- name: "bazel-3.3.1-linux-x86_64 version"
+  command: "bazel-3.3.1-linux-x86_64"
+  args: ["version"]
+  expectedOutput: ['Build\ label:\ 3\.3\.1']
+- name: "bazel 3.3.1 version"
+  command: "bazel"
+  envVars: [{ key: "USE_BAZEL_VERSION", value: "3.3.1" }]
+  args: ["version"]
+  expectedOutput: ['Build\ label:\ 3\.3\.1']
+
+- name: "which bazel-3.4.1-linux-x86_64"
+  command: "which"
+  args: ["bazel-3.4.1-linux-x86_64"]
+  expectedOutput: ["/usr/local/bin/bazel-3.4.1-linux-x86_64"]
+- name: "bazel-3.4.1-linux-x86_64 version"
+  command: "bazel-3.4.1-linux-x86_64"
+  args: ["version"]
+  expectedOutput: ['Build\ label:\ 3\.4\.1']
+- name: "bazel 3.4.1 version"
+  command: "bazel"
+  envVars: [{ key: "USE_BAZEL_VERSION", value: "3.4.1" }]
+  args: ["version"]
+  expectedOutput: ['Build\ label:\ 3\.4\.1']
+
 - name: "bazel version"
   command: "bazel"
   args: ["version"]
-  expectedOutput: ['Build\ label:\ 3\.2\.0']
+  expectedOutput: ['Build\ label:\ 3\.4\.1']
 
 fileExistenceTests:
 - name: '/usr/local/bin/bazel'


### PR DESCRIPTION
Envoy and envoy-build-tools already support and require newer versions
of Bazel.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>