### PR TITLE
scripts: use sed in place editing

### DIFF
--- a/scripts/update-alpine-base-image.sh
+++ b/scripts/update-alpine-base-image.sh
@@ -27,5 +27,5 @@ image_digest="$("${script_dir}/get-image-digest.sh" "${image}")"
 used_by=($(git grep -l ALPINE_BASE_IMAGE= images))
 
 for i in "${used_by[@]}" ; do
-  sed "s|\(ALPINE_BASE_IMAGE=\)docker.io/library/alpine:.*\$|\1${image}@${image_digest}|" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"
+  sed -i "s|\(ALPINE_BASE_IMAGE=\)docker.io/library/alpine:.*\$|\1${image}@${image_digest}|" "${i}"
 done

--- a/scripts/update-compilers-image.sh
+++ b/scripts/update-compilers-image.sh
@@ -29,5 +29,5 @@ image_digest="$("${script_dir}/get-image-digest.sh" "${image_name}:${image_tag}"
 used_by=($(git grep -l COMPILERS_IMAGE= images))
 
 for i in "${used_by[@]}" ; do
-  sed "s|\(COMPILERS_IMAGE=${image_name}\):.*\$|\1:${image_tag}@${image_digest}|" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"
+  sed -i "s|\(COMPILERS_IMAGE=${image_name}\):.*\$|\1:${image_tag}@${image_digest}|" "${i}"
 done

--- a/scripts/update-golang-image.sh
+++ b/scripts/update-golang-image.sh
@@ -27,5 +27,5 @@ image_digest="$("${script_dir}/get-image-digest.sh" "${image}")"
 used_by=($(git grep -l GOLANG_IMAGE= images))
 
 for i in "${used_by[@]}" ; do
-  sed "s|\(GOLANG_IMAGE=\)docker.io/library/golang:.*\$|\1${image}@${image_digest}|" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"
+  sed -i "s|\(GOLANG_IMAGE=\)docker.io/library/golang:.*\$|\1${image}@${image_digest}|" "${i}"
 done

--- a/scripts/update-maker-image.sh
+++ b/scripts/update-maker-image.sh
@@ -27,12 +27,12 @@ image_tag="$(WITHOUT_SUFFIX=1 "${script_dir}/make-image-tag.sh" images/maker)"
 used_by_workflows=($(git grep -l "docker://${image_name}:" .github/workflows))
 
 for i in "${used_by_workflows[@]}" ; do
-  sed "s|\(docker://${image_name}\):.*\$|\1:${image_tag}|" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"
+  sed -i "s|\(docker://${image_name}\):.*\$|\1:${image_tag}|" "${i}"
 done
 
 # shellcheck disable=SC2207
-used_by_scripts=($(git grep -l  "MAKER_IMAGE=\"\${MAKER_IMAGE:-${image_name}:" "${script_dir}"))
+used_by_scripts=($(git grep -l "MAKER_IMAGE=\"\${MAKER_IMAGE:-${image_name}:" "${script_dir}"))
 
 for i in "${used_by_scripts[@]}" ; do
-  sed "s|\(MAKER_IMAGE=\"\${MAKER_IMAGE:-${image_name}\):.*\(}\"\)\$|\1:${image_tag}\2|" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}" && chmod +x "${i}"
+  sed -i "s|\(MAKER_IMAGE=\"\${MAKER_IMAGE:-${image_name}\):.*\(}\"\)\$|\1:${image_tag}\2|" "${i}" && chmod +x "${i}"
 done

--- a/scripts/update-tester-image.sh
+++ b/scripts/update-tester-image.sh
@@ -29,5 +29,5 @@ image_digest="$("${script_dir}/get-image-digest.sh" "${image_name}:${image_tag}"
 used_by=($(git grep -l TESTER_IMAGE= images))
 
 for i in "${used_by[@]}" ; do
-  sed "s|\(TESTER_IMAGE=${image_name}\):.*\$|\1:${image_tag}@${image_digest}|" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"
+  sed -i "s|\(TESTER_IMAGE=${image_name}\):.*\$|\1:${image_tag}@${image_digest}|" "${i}"
 done


### PR DESCRIPTION
Use `sed -i ... ${f}` instead of `sed ... ${f} > ${f}.sedtmp && mv ${f}.sedtmp ${f}`

This also makes sure that the edited file is renamed atomically and
permissions are retained.

Reference: https://github.com/cilium/cilium/pull/12853#discussion_r469748425
Suggested-by: Alexandre Perrin <alex@kaworu.ch>
Signed-off-by: Tobias Klauser <tklauser@distanz.ch>