### PR TITLE
bpftool: fix up test for versioning

### DIFF
--- a/images/bpftool/test/spec.yaml
+++ b/images/bpftool/test/spec.yaml
@@ -15,4 +15,4 @@ commandTests:
   command: "bpftool"
   args: ["version"]
   expectedOutput:
-  - 'bpftool\ v5\.9\.0-rc6'
+  - 'bpftool\ v5\.9\.0'


### PR DESCRIPTION
Same as done in a35f2e9d36a1 ("Update bpftool version string test") where
it slipped through given tests are only run after merge and not on PRs. :-/

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>