### PR TITLE
checkpatch: improve Dockerfile

### DIFF
--- a/images/checkpatch/Dockerfile
+++ b/images/checkpatch/Dockerfile
@@ -7,9 +7,12 @@ ARG ALPINE_BASE_IMAGE=docker.io/library/alpine:3.11@sha256:9a839e63dad54c3a6d183
 FROM ${ALPINE_BASE_IMAGE} as builder
 LABEL maintainer="maintainer@cilium.io"
 
-COPY . /opt/checkpatch
+COPY . /checkpatch
 
-WORKDIR /opt/checkpatch
-RUN for i in fixes/*.diff; do patch -p1 < "$i"; done
+RUN for i in /checkpatch/fixes/*.diff; do \
+    patch -p1 /checkpatch/checkpatch.pl < "$i"; \
+    done
 
 RUN apk add --no-cache bash git jq perl
+
+ENTRYPOINT ["/checkpatch/checkpatch.sh"]

--- a/images/checkpatch/README.md
+++ b/images/checkpatch/README.md
@@ -18,13 +18,13 @@ Public License (GPL) version 2 (see file [COPYING](COPYING)).
 ## Bash Script and Other Additions
 
 The bash wrapper is used to call the `checkpatch.pl` script with the relevant
-options and arguments for working on Cilium's code base. It passes makes sure
+options and arguments for working on Cilium's code base. It makes sure
 `checkpatch.pl` is run on the latest commits or, if the `-a` option is passed,
 on the source files under the `bpf/` directory. It should be executed from the
 root of Cilium's repository:
 
 ```
-docker run --rm --user 1000 -it --workdir /workspace -v $PWD:/workspace <container_id> /opt/checkpatch/checkpatch.sh
+docker run --rm --user $(id -u):$(id -g) -it --workdir /workspace -v $PWD:/workspace <container_id>
 ```
 
 The list of deprecated terms was specifically added for Cilium.


### PR DESCRIPTION
- Remove the `WORKDIR` directive (and simply uses absolute paths where necessary instead). This is to avoid any confusion when using the container with a GitHub action, for which the working directory is set through the `GITHUB_WORKSPACE` variable. It should not matter much as we need to mount a volume to point to Cilium's source code to check in any case, but better be safe than sorry.

- Remove the `/opt` prefix for the checkpatch directory in the container, as installing under the root seems a common practice and the prefix only makes path names longer to type.

- Add an entrypoint to the container image, as this should be constant for all invocations of the container.

- Update the documentation for the checkpatch image accordingly, improve example command line (and fix a typo).
