### PR TITLE
checkpatch: add curl to the image

### DIFF
--- a/images/checkpatch/Dockerfile
+++ b/images/checkpatch/Dockerfile
@@ -13,6 +13,6 @@ RUN for i in /checkpatch/fixes/*.diff; do \
     patch -p1 /checkpatch/checkpatch.pl < "$i"; \
     done
 
-RUN apk add --no-cache bash git jq perl
+RUN apk add --no-cache bash curl git jq perl
 
 ENTRYPOINT ["/checkpatch/checkpatch.sh"]


### PR DESCRIPTION
Curl is necessary to run the `checkpatch.sh` script as a GitHub Action, but it is not present on the Alpine image by default. Let's install it when building the image.
