### PR TITLE
llvm: Include llvm-objcopy in the image

### DIFF
--- a/images/llvm/build-llvm-cross-aarch64.sh
+++ b/images/llvm/build-llvm-cross-aarch64.sh
@@ -26,10 +26,11 @@ CC="${triplet}-gcc" CXX="${triplet}-g++" \
     -DCMAKE_CROSSCOMPILING="True" \
     -DCMAKE_INSTALL_PREFIX="/usr/local"
 
-ninja clang llc
+ninja clang llc llvm-objcopy
 
 ${triplet}-strip bin/clang
 ${triplet}-strip bin/llc
+${triplet}-strip bin/llvm-objcopy
 
 mkdir -p /out/linux/arm64/bin
-cp bin/clang bin/llc /out/linux/arm64/bin
+cp bin/clang bin/llc bin/llvm-objcopy /out/linux/arm64/bin

--- a/images/llvm/build-llvm-native.sh
+++ b/images/llvm/build-llvm-native.sh
@@ -20,10 +20,11 @@ cmake .. -G "Ninja" \
   -DLLVM_BUILD_RUNTIME="OFF" \
   -DCMAKE_INSTALL_PREFIX="/usr/local"
 
-ninja clang llc
+ninja clang llc llvm-objcopy
 
 strip bin/clang
 strip bin/llc
+strip bin/llvm-objcopy
 
 mkdir -p /out/linux/amd64/bin
-cp bin/clang bin/llc /out/linux/amd64/bin
+cp bin/clang bin/llc bin/llvm-objcopy /out/linux/amd64/bin


### PR DESCRIPTION
The `llvm-objcopy` binary will be used in the 4.19 CI test for verifier errors. It is required to remove global data sections which libbpf rejects in newer kernels.

The new cilium-llvm image will then be used in https://github.com/cilium/cilium/pull/13953, which I'll need to update.