### PR TITLE
iproute2: bump to latest revision of static-data branch

### DIFF
--- a/images/iproute2/checkout-iproute2.sh
+++ b/images/iproute2/checkout-iproute2.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-rev="7010f7758df5cd3d7bc5a4ffa5e73b9038211def"
+rev="cee19aa079794a7bdb3a64f414e88a6612a5b376"
 
 # git clone https://github.com/cilium/iproute2 /src/iproute2
 # cd /src/iproute2


### PR DESCRIPTION
This version includes a fix to symlink some bpf directories as a
relative path of 'tc' instead of being a absolute path [1].

[1] - https://github.com/cilium/iproute2/pull/7
Signed-off-by: André Martins <andre@cilium.io>