### PR TITLE
checkpatch: Support GitHub's Co-authored-by

### DIFF
--- a/images/checkpatch/README.md
+++ b/images/checkpatch/README.md
@@ -41,7 +41,8 @@ When building the Docker image, several patches are applied to the script.
   was [submitted for upstream inclusion](https://lore.kernel.org/patchwork/patch/1265784/),
   but rejected by the maintainer.
 
-* `fixes/use-CODEOWNERS-instead-of-MAINTAINERS.diff`: Cilium has a `CODEOWNERS`
-  file instead of the `MAINTAINERS` used by the Linux kernel. Replace a few
-  occurrences in `checkpatch.pl`, where relevant, to check and point to the
-  correct owner file when new source code files are added.
+* `fixes/recognize-co-authored-by.diff`: Cilium developers sometimes use the
+  `Co-authored-by:` tag in commit logs, to indicate that several authors
+  contributed to the patch. Checkpatch understands this is some kind of tag,
+  but not one it knows of, and it complains with a warning. This patch teaches
+  it about the tag.

--- a/images/checkpatch/fixes/recognize-co-authored-by.diff
+++ b/images/checkpatch/fixes/recognize-co-authored-by.diff
@@ -1,0 +1,12 @@
+diff --git a/script/checkpatch.pl b/script/checkpatch.pl
+index 3cacc12..21244d4 100755
+--- a/checkpatch.pl
++++ b/checkpatch.pl
+@@ -494,6 +494,7 @@ our $allocFunctions = qr{(?x:
+ our $signature_tags = qr{(?xi:
+ 	Signed-off-by:|
+ 	Co-developed-by:|
++	Co-authored-by:|
+ 	Acked-by:|
+ 	Tested-by:|
+ 	Reviewed-by:|


### PR DESCRIPTION
GitHub supports the annotation Co-authored-by for commits with several authors. Checkpatch should recognize it as well to avoid false positives.