### PR TITLE
update compilers test

### DIFF
--- a/images/compilers/test/spec.yaml
+++ b/images/compilers/test/spec.yaml
@@ -22,118 +22,6 @@ commandTests:
   - 'Target:\ aarch64-linux-gnu'
   - 'gcc\ version\ 9\.3\.0'
 
-- name: "which bazel-2.0.0-linux-x86_64"
-  command: "which"
-  args: ["bazel-2.0.0-linux-x86_64"]
-  expectedOutput: ["/usr/local/bin/bazel-2.0.0-linux-x86_64"]
-- name: "which bazel-2.0.0-linux-x86_64 version"
-  command: "bazel-2.0.0-linux-x86_64"
-  args: ["version"]
-  expectedOutput: ['Build\ label:\ 2\.0\.0']
-- name: "bazel 2.0.0 version"
-  command: "bazel"
-  envVars: [{ key: "USE_BAZEL_VERSION", value: "2.0.0" }]
-  args: ["version"]
-  expectedOutput: ['Build\ label:\ 2\.0\.0']
-
-- name: "which bazel-2.2.0-linux-x86_64"
-  command: "which"
-  args: ["bazel-2.2.0-linux-x86_64"]
-  expectedOutput: ["/usr/local/bin/bazel-2.2.0-linux-x86_64"]
-- name: "bazel-2.2.0-linux-x86_64 version"
-  command: "bazel-2.2.0-linux-x86_64"
-  args: ["version"]
-  expectedOutput: ['Build\ label:\ 2\.2\.0']
-- name: "bazel 2.2.0 version"
-  command: "bazel"
-  envVars: [{ key: "USE_BAZEL_VERSION", value: "2.2.0" }]
-  args: ["version"]
-  expectedOutput: ['Build\ label:\ 2\.2\.0']
-
-- name: "which bazel-3.1.0-linux-x86_64"
-  command: "which"
-  args: ["bazel-3.1.0-linux-x86_64"]
-  expectedOutput: ["/usr/local/bin/bazel-3.1.0-linux-x86_64"]
-- name: "bazel-3.1.0-linux-x86_64 version"
-  command: "bazel-3.1.0-linux-x86_64"
-  args: ["version"]
-  expectedOutput: ['Build\ label:\ 3\.1\.0']
-- name: "bazel 3.1.0 version"
-  command: "bazel"
-  envVars: [{ key: "USE_BAZEL_VERSION", value: "3.1.0" }]
-  args: ["version"]
-  expectedOutput: ['Build\ label:\ 3\.1\.0']
-
-- name: "which bazel-3.2.0-linux-x86_64"
-  command: "which"
-  args: ["bazel-3.2.0-linux-x86_64"]
-  expectedOutput: ["/usr/local/bin/bazel-3.2.0-linux-x86_64"]
-- name: "bazel-3.2.0-linux-x86_64 version"
-  command: "bazel-3.2.0-linux-x86_64"
-  args: ["version"]
-  expectedOutput: ['Build\ label:\ 3\.2\.0']
-- name: "bazel 3.2.0 version"
-  command: "bazel"
-  envVars: [{ key: "USE_BAZEL_VERSION", value: "3.2.0" }]
-  args: ["version"]
-  expectedOutput: ['Build\ label:\ 3\.2\.0']
-
-- name: "which bazel-3.3.1-linux-x86_64"
-  command: "which"
-  args: ["bazel-3.3.1-linux-x86_64"]
-  expectedOutput: ["/usr/local/bin/bazel-3.3.1-linux-x86_64"]
-- name: "bazel-3.3.1-linux-x86_64 version"
-  command: "bazel-3.3.1-linux-x86_64"
-  args: ["version"]
-  expectedOutput: ['Build\ label:\ 3\.3\.1']
-- name: "bazel 3.3.1 version"
-  command: "bazel"
-  envVars: [{ key: "USE_BAZEL_VERSION", value: "3.3.1" }]
-  args: ["version"]
-  expectedOutput: ['Build\ label:\ 3\.3\.1']
-
-- name: "which bazel-3.4.1-linux-x86_64"
-  command: "which"
-  args: ["bazel-3.4.1-linux-x86_64"]
-  expectedOutput: ["/usr/local/bin/bazel-3.4.1-linux-x86_64"]
-- name: "bazel-3.4.1-linux-x86_64 version"
-  command: "bazel-3.4.1-linux-x86_64"
-  args: ["version"]
-  expectedOutput: ['Build\ label:\ 3\.4\.1']
-- name: "bazel 3.4.1 version"
-  command: "bazel"
-  envVars: [{ key: "USE_BAZEL_VERSION", value: "3.4.1" }]
-  args: ["version"]
-  expectedOutput: ['Build\ label:\ 3\.4\.1']
-
-- name: "which bazel-3.5.1-linux-x86_64"
-  command: "which"
-  args: ["bazel-3.5.1-linux-x86_64"]
-  expectedOutput: ["/usr/local/bin/bazel-3.5.1-linux-x86_64"]
-- name: "bazel-3.5.1-linux-x86_64 version"
-  command: "bazel-3.5.1-linux-x86_64"
-  args: ["version"]
-  expectedOutput: ['Build\ label:\ 3\.5\.1']
-- name: "bazel 3.5.1 version"
-  command: "bazel"
-  envVars: [{ key: "USE_BAZEL_VERSION", value: "3.5.1" }]
-  args: ["version"]
-  expectedOutput: ['Build\ label:\ 3\.5\.1']
-
-- name: "which bazel-3.6.0-linux-x86_64"
-  command: "which"
-  args: ["bazel-3.6.0-linux-x86_64"]
-  expectedOutput: ["/usr/local/bin/bazel-3.6.0-linux-x86_64"]
-- name: "bazel-3.6.0-linux-x86_64 version"
-  command: "bazel-3.6.0-linux-x86_64"
-  args: ["version"]
-  expectedOutput: ['Build\ label:\ 3\.6\.0']
-- name: "bazel 3.6.0 version"
-  command: "bazel"
-  envVars: [{ key: "USE_BAZEL_VERSION", value: "3.6.0" }]
-  args: ["version"]
-  expectedOutput: ['Build\ label:\ 3\.6\.0']
-
 - name: "which bazel-3.7.0-linux-x86_64"
   command: "which"
   args: ["bazel-3.7.0-linux-x86_64"]
@@ -148,10 +36,38 @@ commandTests:
   args: ["version"]
   expectedOutput: ['Build\ label:\ 3\.7\.0']
 
+- name: "which bazel-3.7.1-linux-x86_64"
+  command: "which"
+  args: ["bazel-3.7.1-linux-x86_64"]
+  expectedOutput: ["/usr/local/bin/bazel-3.7.1-linux-x86_64"]
+- name: "bazel-3.7.1-linux-x86_64 version"
+  command: "bazel-3.7.1-linux-x86_64"
+  args: ["version"]
+  expectedOutput: ['Build\ label:\ 3\.7\.1']
+- name: "bazel 3.7.1 version"
+  command: "bazel"
+  envVars: [{ key: "USE_BAZEL_VERSION", value: "3.7.1" }]
+  args: ["version"]
+  expectedOutput: ['Build\ label:\ 3\.7\.1']
+
+- name: "which bazel-3.7.2-linux-x86_64"
+  command: "which"
+  args: ["bazel-3.7.2-linux-x86_64"]
+  expectedOutput: ["/usr/local/bin/bazel-3.7.2-linux-x86_64"]
+- name: "bazel-3.7.2-linux-x86_64 version"
+  command: "bazel-3.7.2-linux-x86_64"
+  args: ["version"]
+  expectedOutput: ['Build\ label:\ 3\.7\.2']
+- name: "bazel 3.7.2 version"
+  command: "bazel"
+  envVars: [{ key: "USE_BAZEL_VERSION", value: "3.7.2" }]
+  args: ["version"]
+  expectedOutput: ['Build\ label:\ 3\.7\.2']
+
 - name: "bazel version"
   command: "bazel"
   args: ["version"]
-  expectedOutput: ['Build\ label:\ 3\.7\.0']
+  expectedOutput: ['Build\ label:\ 3\.7\.2']
 
 fileExistenceTests:
 - name: '/usr/local/bin/bazel'


### PR DESCRIPTION
Fixes: e4680365fb11 ("compilers: update bazel to 3.7.2 and remove older versions")
Signed-off-by: André Martins <andre@cilium.io>