### PR TITLE
Makefile: remove ability to push to docker.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-REGISTRIES ?= docker.io/cilium quay.io/cilium
+REGISTRIES ?= quay.io/cilium
 
 PUSH ?= false
 EXPORT ?= false


### PR DESCRIPTION
As it is not possible to fine tune repository permissions to a
particular DockerHub account, we can't reuse it in multiple
repositories. We will use quay.io for the images build in this
repository.

Signed-off-by: André Martins <andre@cilium.io>