### PR TITLE
checkpatch: use $GITHUB_REPOSITORY to pass the repo

### DIFF
--- a/images/checkpatch/checkpatch.sh
+++ b/images/checkpatch/checkpatch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2020 Authors of Cilium
+# Copyright 2020-2021 Authors of Cilium
 
 # Default options for checkpatch
 options=(
@@ -177,7 +177,7 @@ if [ -n "$GITHUB_REF" ]; then
     check_cmd curl
     pr=${GITHUB_REF#"refs/pull/"}
     prnum=${pr%"/merge"}
-    pr_url="https://api.github.com/repos/cilium/cilium/pulls/${prnum}"
+    pr_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${prnum}"
 
     # Skip for backports (if not on main branch)
     base_ref=$(curl -s "${pr_url}" | jq -r '.base.ref')


### PR DESCRIPTION
When retrieving the list of commits for the PR, use the `$GITHUB_REPOSITORY` variable set by the GitHub action instead of hardcoding the name of the repository. This is cleaner, and would potentially be easier to reuse for other repositories.