### PR TITLE
iproute2: Bump to static-data-v5.11 branch

### DIFF
--- a/images/iproute2/Dockerfile
+++ b/images/iproute2/Dockerfile
@@ -9,6 +9,15 @@ ARG TESTER_IMAGE=docker.io/cilium/image-tester:6316b0f5606a69078bed1dd9f9c2b5685
 
 FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder
 
+COPY checkout-libbpf.sh /tmp/checkout-libbpf.sh
+RUN /tmp/checkout-libbpf.sh
+
+COPY build-libbpf-native.sh /tmp/build-libbpf-native.sh
+RUN /tmp/build-libbpf-native.sh
+
+COPY build-libbpf-cross-aarch64.sh /tmp/build-libbpf-cross-aarch64.sh
+RUN /tmp/build-libbpf-cross-aarch64.sh
+
 COPY checkout-iproute2.sh /tmp/checkout-iproute2.sh
 RUN /tmp/checkout-iproute2.sh
 
@@ -29,6 +38,7 @@ RUN --mount=type=tmpfs,target=/var/cache/apt --mount=type=tmpfs,target=/var/lib/
     && apt-get install -y --no-install-recommends libelf1 libmnl0 \
     && apt-get purge --auto-remove -y
 
+COPY --from=builder /out/${TARGETPLATFORM}/lib64 /usr/lib
 COPY --from=builder /out/${TARGETPLATFORM}/bin /usr/local/bin
 COPY test /test/iproute2
 

--- a/images/iproute2/build-iproute2-cross-aarch64.sh
+++ b/images/iproute2/build-iproute2-cross-aarch64.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017-2020 Authors of Cilium
+# Copyright 2017-2021 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
 set -o xtrace
@@ -14,7 +14,12 @@ cd /src/iproute2
 
 make distclean
 
-PKG_CONFIG="${triplet}-pkg-config" CC="${triplet}-gcc" AR="${triplet}-ar" ./configure
+LIBBPF_FORCE="on"					\
+PKG_CONFIG_PATH="/out/linux/arm64/lib64/pkgconfig"	\
+PKG_CONFIG="${triplet}-pkg-config --define-prefix"	\
+CC="${triplet}-gcc"					\
+AR="${triplet}-ar"					\
+./configure
 
 make -j "$(getconf _NPROCESSORS_ONLN)"
 

--- a/images/iproute2/build-iproute2-native.sh
+++ b/images/iproute2/build-iproute2-native.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017-2020 Authors of Cilium
+# Copyright 2017-2021 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
 set -o xtrace
@@ -10,6 +10,9 @@ set -o nounset
 
 cd /src/iproute2
 
+LIBBPF_FORCE="on"					\
+PKG_CONFIG_PATH="/out/linux/amd64/lib64/pkgconfig"	\
+PKG_CONFIG="pkg-config --define-prefix"			\
 ./configure
 
 make -j "$(getconf _NPROCESSORS_ONLN)"

--- a/images/iproute2/build-libbpf-cross-aarch64.sh
+++ b/images/iproute2/build-libbpf-cross-aarch64.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright 2021 Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+set -o nounset
+
+triplet="aarch64-linux-gnu"
+
+cd /src/libbpf/src
+
+make clean
+CC="${triplet}-gcc"			\
+AR="${triplet}-ar"			\
+make -j "$(getconf _NPROCESSORS_ONLN)"
+
+PREFIX="/out/linux/arm64/"		\
+PKG_CONFIG="${triplet}-pkg-config"	\
+make install

--- a/images/iproute2/build-libbpf-native.sh
+++ b/images/iproute2/build-libbpf-native.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Copyright 2021 Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+set -o nounset
+
+cd /src/libbpf/src
+
+make clean
+make -j "$(getconf _NPROCESSORS_ONLN)"
+PREFIX="/out/linux/amd64/"		\
+make install

--- a/images/iproute2/checkout-iproute2.sh
+++ b/images/iproute2/checkout-iproute2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017-2020 Authors of Cilium
+# Copyright 2017-2021 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
 set -o xtrace
@@ -8,7 +8,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-rev="cee19aa079794a7bdb3a64f414e88a6612a5b376"
+rev="28228d82c12d91d1d04ed614690c047f58f9f1bc" # static-data-v5.11
 
 # git clone https://github.com/cilium/iproute2 /src/iproute2
 # cd /src/iproute2

--- a/images/iproute2/checkout-libbpf.sh
+++ b/images/iproute2/checkout-libbpf.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright 2017-2021 Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+set -o nounset
+
+rev="e1a90f3768fda85da958c37515f9e8cb6d3d6a92" # master@2021-02-26
+
+# git clone https://github.com/libbpf/libbpf /src/libbpf
+# cd /src/libbpf
+# git checkout -b "build-${rev:0:7}" "${rev}
+
+# It is much quicker to download a tarball then a full git checkout,
+curl --fail --show-error --silent --location "https://github.com/libbpf/libbpf/archive/${rev}.tar.gz" --output /tmp/libbpf.tgz
+mkdir -p /src
+tar -xf /tmp/libbpf.tgz -C /tmp
+mv "/tmp/libbpf-${rev}" /src/libbpf
+rm -f /tmp/libbpf.tgz

--- a/images/iproute2/test/spec.yaml
+++ b/images/iproute2/test/spec.yaml
@@ -32,14 +32,14 @@ commandTests:
   command: "ip"
   args: ["-V"]
   expectedOutput:
-  - 'ip\ utility,\ iproute2-ss190107'
+  - 'ip\ utility,\ iproute2-5.11.0\+cilium.0'
 - name: "tc -V"
   command: "tc"
   args: ["-V"]
   expectedOutput:
-  - 'tc\ utility,\ iproute2-ss190107'
+  - 'tc\ utility,\ iproute2-5.11.0\+cilium.0'
 - name: "ss -V"
   command: "ss"
   args: ["-V"]
   expectedOutput:
-  - 'ss\ utility,\ iproute2-ss190107'
+  - 'ss\ utility,\ iproute2-5.11.0\+cilium.0'

--- a/images/iproute2/test/spec.yaml
+++ b/images/iproute2/test/spec.yaml
@@ -43,3 +43,9 @@ commandTests:
   args: ["-V"]
   expectedOutput:
   - 'ss\ utility,\ iproute2-5.11.0\+cilium.0'
+
+- name: "tc is linked against libbpf"
+  command: "ldd"
+  args: ["/usr/local/bin/tc"]
+  expectedOutput:
+  - '/libbpf.so'


### PR DESCRIPTION
Bump the cilium-iproute2 image to point to the following branch:

https://github.com/cilium/iproute2/commits/static-data-v5.11

Then while we're at it, pull & build against libbpf.