### PR TITLE
iproute2: bump to latest revision of static-data branch

### DIFF
--- a/images/iproute2/checkout-iproute2.sh
+++ b/images/iproute2/checkout-iproute2.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-rev="cee19aa079794a7bdb3a64f414e88a6612a5b376"
+rev="474d7b7a102f52d54a9b4a77785104ce7a5c49de"
 
 # git clone https://github.com/cilium/iproute2 /src/iproute2
 # cd /src/iproute2


### PR DESCRIPTION
This version includes a backport of upstream support for setting the xfrm output mark's mask (cf. https://github.com/cilium/iproute2/pull/8).