### PR TITLE
images/maker: fix building Go deps

### DIFF
--- a/images/maker/build-go-deps.sh
+++ b/images/maker/build-go-deps.sh
@@ -16,8 +16,8 @@ export CGO_ENABLED=0
 
 mkdir -p /out/usr/local/bin
 
-# TODO: use `go install ...@<version>` instead
-GO111MODULE=off go build -ldflags '-s -w' -o /out/usr/local/bin/docker-credential-env github.com/errordeveloper/docker-credential-env
-GO111MODULE=off go build -ldflags '-s -w' -o /out/usr/local/bin/imagine github.com/errordeveloper/imagine
-GO111MODULE=off go build -ldflags '-s -w' -o /out/usr/local/bin/kg github.com/errordeveloper/kue/cmd/kg
-GO111MODULE=off go build -ldflags '-s -w' -o /out/usr/local/bin/docker-buildx github.com/docker/buildx/cmd/buildx
+go mod download
+go build -ldflags '-s -w' -o /out/usr/local/bin/docker-credential-env github.com/errordeveloper/docker-credential-env
+go build -ldflags '-s -w' -o /out/usr/local/bin/imagine github.com/errordeveloper/imagine
+go build -ldflags '-s -w' -o /out/usr/local/bin/kg github.com/errordeveloper/kue/cmd/kg
+go build -ldflags '-s -w' -o /out/usr/local/bin/docker-buildx github.com/docker/buildx/cmd/buildx


### PR DESCRIPTION
Instead of using `go install <pkg>@<version>`, add `go mod download`,
as `go.mod` file is already present with the versions. Older version
of Go used to implicitly perform the download, but looks like it refuses
to do it now without a `go.sum`.

This is a follow-up to #115 