### PR TITLE
.github: only run workflows for pushes to master branch

### DIFF
--- a/.github/workflows/kube-test.yaml
+++ b/.github/workflows/kube-test.yaml
@@ -1,5 +1,9 @@
 name: Validate kube-test image
-on: [pull_request,push]
+on:
+  pull_request: {}
+  push:
+    branches:
+    - master
 
 jobs:
   build-kube-test-image:

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,5 +1,9 @@
 name: PR Check
-on: [pull_request,push]
+on:
+  pull_request: {}
+  push:
+    branches:
+    - master
 
 jobs:
   lint:


### PR DESCRIPTION
Otherwise, when opening PRs from branches on
github.com/cilium/image-tools, each workflow gets instantiated twice,
once for the `on: pull_request` and once for `on: push`. Avoid this by
restricting `on: push` to pushes to the master branch.

FWIW, this is done in the same way on the github.com/cilium/cilium repo.