### PR TITLE
test-verifier: New image for use in K8sVerifier test

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -119,3 +119,13 @@ jobs:
         with:
           entrypoint: make
           args: checkpatch-image PUSH=true
+      - uses: docker://docker.io/cilium/image-maker:8fb8f8325d966505552183f756eae4e3cb60d195
+        name: Run make test-verifier-image
+        env:
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_CI }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD_IMAGE_TOOLS }}
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME_IMAGE_TOOLS }}
+        with:
+          entrypoint: make
+          args: test-verifier-image PUSH=true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,3 +15,4 @@
 /images/checkpatch @cilium/bpf
 /images/llvm @cilium/loader
 /images/iproute2 @cilium/loader
+/images/test-verifier @cilium/loader

--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,6 @@ startup-script-image: .buildx_builder
 
 checkpatch-image: .buildx_builder
 	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh cilium-checkpatch images/checkpatch linux/amd64 "$$(cat .buildx_builder)" $(REGISTRIES)
+
+test-verifier-image: .buildx_builder
+	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh test-verifier images/test-verifier linux/amd64 "$$(cat .buildx_builder)" $(REGISTRIES)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ This image packages the [checkpatch.pl](images/checkpatch/checkpatch.pl) script 
 
 While the script itself is directly copied from [the upstream version in the kernel repository](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/scripts/checkpatch.pl), a number of patches are applied before the script is run. These patch mostly address a number of false positives for Cilium's code base.
 
+### [`images/test-verifier`](images/test-verifier/Dockerfile)
+
+This image packages all the tools necessary to compile and load Cilium's BPF datapath, including Clang, bpftool, tc, ip, and gcc.
+
 ### [`images/tester`](images/tester/Dockerfile)
 
 This image contains a [simple Go program](images/tester/cst/main.go), which is a minimal version of [`container-structure-test`](https://github.com/GoogleContainerTools/container-structure-test).

--- a/images/test-verifier/Dockerfile
+++ b/images/test-verifier/Dockerfile
@@ -1,0 +1,30 @@
+ARG CILIUM_LLVM_IMAGE=quay.io/cilium/cilium-llvm:0147a23fdada32bd51b4f313c645bcb5fbe188d6@sha256:24fd3ad32471d0e45844c856c38f1b2d4ac8bd0a2d4edf64cffaaa3fd0b21202
+ARG CILIUM_BPFTOOL_IMAGE=quay.io/cilium/cilium-bpftool:b5ba881d2a7ec68d88ecd72efd60ac551c720701@sha256:458282e59657b8f779d52ae2be2cdbeecfe68c3d807ff87c97c8d5c6f97820a9
+ARG GOLANG_IMAGE=docker.io/library/golang:1.16.4@sha256:07a471a939cd942ed5c23714185dac476df214f94cf073ef2fbfa748d4926a48
+
+FROM ${CILIUM_LLVM_IMAGE} as llvm-dist
+FROM ${CILIUM_BPFTOOL_IMAGE} as bpftool-dist
+FROM ${GOLANG_IMAGE} as golang-dist
+
+FROM docker.io/library/ubuntu:20.04@sha256:b4aa552dd3f2ed84f3214b0e8add3648aee0205ef58295c92fe0899f96ad8755
+
+ENV DEBIAN_FRONTEND noninteractive
+WORKDIR /tmp
+COPY iproute2.diff .
+COPY install-tc-ip.sh .
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends make gcc libelf-dev libmnl-dev && \
+    ./install-tc-ip.sh && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=golang-dist /usr/local/go /usr/local/go
+RUN mkdir -p /go
+ENV GOROOT /usr/local/go
+ENV GOPATH /go
+ENV PATH "${GOROOT}/bin:${GOPATH}/bin:${PATH}"
+
+COPY --from=llvm-dist /usr/local/bin/clang /bin/
+COPY --from=llvm-dist /usr/local/bin/llc /bin/
+COPY --from=llvm-dist /usr/local/bin/llvm-objcopy /bin/
+COPY --from=bpftool-dist /usr/local/bin/bpftool /bin/

--- a/images/test-verifier/README.md
+++ b/images/test-verifier/README.md
@@ -1,0 +1,8 @@
+# test-verifier Image
+
+This directory contains the files necessary to build the test-verifier
+Docker image, used in Cilium's end-to-end test K8sVerifier.
+
+That image has everything necessary to build maptool, cilium-migrate-map,
+and Cilium's BPF datapath, as well as tooling to load the datapath once
+compiled (bpftool, tc, ip).

--- a/images/test-verifier/install-tc-ip.sh
+++ b/images/test-verifier/install-tc-ip.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020-2021 Authors of Cilium
+
+set -e
+
+apt-get install -y --no-install-recommends git bison flex pkg-config ca-certificates
+
+git clone -b static-data --depth 1 https://github.com/cilium/iproute2
+cd iproute2
+git apply ../iproute2.diff
+make -j"$(nproc)"
+cd ..
+
+cp iproute2/tc/tc /bin/
+cp iproute2/ip/ip /bin/
+
+rm -r iproute2
+apt-get autoremove -y git bison flex pkg-config ca-certificates
+apt-get purge --auto-remove

--- a/images/test-verifier/iproute2.diff
+++ b/images/test-verifier/iproute2.diff
@@ -1,0 +1,22 @@
+diff --git a/lib/bpf.c b/lib/bpf.c
+index 512c4e3b..0d9134de 100644
+--- a/lib/bpf.c
++++ b/lib/bpf.c
+@@ -1325,7 +1325,7 @@ bpf_dump_error(struct bpf_elf_ctx *ctx, const char *format, ...)
+ 
+ static int bpf_log_realloc(struct bpf_elf_ctx *ctx)
+ {
+-	const size_t log_max = UINT_MAX >> 8;
++	const size_t log_max = UINT_MAX >> 2;
+ 	size_t log_size = ctx->log_size;
+ 	char *ptr;
+ 
+@@ -1636,7 +1636,7 @@ retry:
+ 		 * log for the user, so enlarge it and re-fail.
+ 		 */
+ 		if (fd < 0 && (errno == ENOSPC || !ctx->log_size)) {
+-			if (tries++ < 10 && !bpf_log_realloc(ctx))
++			if (tries++ < 15 && !bpf_log_realloc(ctx))
+ 				goto retry;
+ 
+ 			fprintf(stderr, "Log buffer too small to dump verifier log %zu bytes (%d tries)!\n",


### PR DESCRIPTION
This new image will be used in the K8sVerifier test in replacement for cilium-builder. It includes a custom patch of iproute2 to work around issues with the log buffer size.