### PR TITLE
images/maker: fix building Go deps (again)

### DIFF
--- a/images/maker/build-go-deps.sh
+++ b/images/maker/build-go-deps.sh
@@ -16,7 +16,7 @@ export CGO_ENABLED=0
 
 mkdir -p /out/usr/local/bin
 
-go mod download
+go mod download all
 go build -ldflags '-s -w' -o /out/usr/local/bin/docker-credential-env github.com/errordeveloper/docker-credential-env
 go build -ldflags '-s -w' -o /out/usr/local/bin/imagine github.com/errordeveloper/imagine
 go build -ldflags '-s -w' -o /out/usr/local/bin/kg github.com/errordeveloper/kue/cmd/kg


### PR DESCRIPTION
There appears to be a subtle difference between `go mod download`
and `go mod download all`. This change fixes the following error:
```
 #25 0.469 + mkdir -p /out/usr/local/bin
 #25 0.471 + go mod download
 #25 86.44 + go build -ldflags '-s -w' -o /out/usr/local/bin/docker-credential-env github.com/errordeveloper/docker-credential-env
 #25 86.50 missing go.sum entry for module providing package github.com/errordeveloper/docker-credential-env; to add:
 #25 86.50 	go mod download github.com/errordeveloper/docker-credential-env
```