### PR TITLE
checkpatch: fix issues with commit object/description checks

### DIFF
--- a/images/checkpatch/checkpatch.sh
+++ b/images/checkpatch/checkpatch.sh
@@ -225,7 +225,7 @@ if [ -n "$GITHUB_REF" ]; then
     esac
 
     commits_url="${pr_url}/commits"
-    list_commits=$(curl -s "$commits_url" | jq '[.[]|{sha: .sha, subject: (.commit.message | sub("\n.*"; ""; "m"))}]')
+    list_commits=$(curl -s "$commits_url" | jq '[.[]|{sha: .sha, subject: (.commit.message | sub("\n\n.*"; ""; "m"))}]')
     pr_info="from PR #$prnum"
 else
     # Running locally


### PR DESCRIPTION
This set contains a few fixes for parsing commit objects when checkpatch runs in a GitHub action, and for detecting missing descriptions in commits. Please refer to individual commit logs for details.

Context: We want to detect commits such as [this one](https://github.com/cilium/cilium/pull/16896/commits/f9845d257cb3e3ff66ab6f9608935345c631db67), where the blank line between the object and the description was omitted, and resulted in a very long commit object for git (although GitHub seems to handle it better).