### PR TITLE
Update iproute2+libbpf

### DIFF
--- a/images/iproute2/checkout-iproute2.sh
+++ b/images/iproute2/checkout-iproute2.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-rev="ec3b4a388d479f9a8e0810a543d2e0d7556f9dc9" # libbpf-static-data
+rev="6b545dcf3b8a48c02f82e68d4a3df4a62c836c9d" # libbpf-static-data
 
 # git clone https://github.com/cilium/iproute2 /src/iproute2
 # cd /src/iproute2

--- a/images/iproute2/checkout-libbpf.sh
+++ b/images/iproute2/checkout-libbpf.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-rev="e979be1529ce34209a0db171785645512e56c871"
+rev="435a6def05b1dd7d1e8e19946315122f7e1e776a"
 
 # git clone https://github.com/libbpf/libbpf /src/libbpf
 # cd /src/libbpf


### PR DESCRIPTION
To include libbpf_set_max_verifier_log_output() which will reduce the
verifier log output:
- https://github.com/cilium/iproute2/pull/13
- https://github.com/cilium/libbpf/pull/1

Related: https://github.com/cilium/cilium/issues/17178