### PR TITLE
checkpatch: fix bash script (warning prefix and exit status for GH action)

### DIFF
--- a/images/checkpatch/checkpatch.sh
+++ b/images/checkpatch/checkpatch.sh
@@ -157,6 +157,10 @@ check_commit() {
                 <(echo '+.') |
             "$checkpatch" "${options[@]}" --ignore "$ignores" "${cli_options[@]}" |
             prepend_gh_action_commands "$gh_action"
+        # prepend_gh_action_commands() does not preserve the return code from
+        # checkpatch. Make sure the subshell returns with the status from the
+        # second-to-last command of the pipeline.
+        test "${PIPESTATUS[${#PIPESTATUS[@]}-2]}" -eq 0
     ) || ret=1
     # Apply custom checks on all commits, whether or not they touch bpf/
     custom_checks "$sha" "$subject" "$gh_action"

--- a/images/checkpatch/checkpatch.sh
+++ b/images/checkpatch/checkpatch.sh
@@ -65,7 +65,7 @@ HL_START="\e[1;34m"
 HL_END="\e[0m"
 
 GH_ERROR_PREFIX="::error::"
-GH_WARN_PREFIX="::warn::"
+GH_WARN_PREFIX="::warning::"
 
 usage() {
     echo "Usage: $0 [options] [-- checkpatch.pl options]"


### PR DESCRIPTION
These are two short commits for the checkpatch image.

The first one is a simple fix for the `::warning::` prefix, so that warnings are displayed (and reported) better on the GitHub interface.

The second one is more important, and fix an issue that results in the check being marked as successful on GitHub even when issues are reported.
