### PR TITLE
Update iproute2 to pull in managed neighbor backports

### DIFF
--- a/images/iproute2/checkout-iproute2.sh
+++ b/images/iproute2/checkout-iproute2.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-rev="dc78ae96629945399fe1d1959b404a6c55b554cf" # libbpf-static-data
+rev="b0f3a1a74ae45efd866b12476a4147de90f43ac6" # libbpf-static-data
 
 # git clone https://github.com/cilium/iproute2 /src/iproute2
 # cd /src/iproute2


### PR DESCRIPTION
Pull in backport from https://github.com/cilium/iproute2/pull/15 .

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>