### PR TITLE
images/checkpatch: fix index off-by-one in commit list

### DIFF
--- a/images/checkpatch/checkpatch.sh
+++ b/images/checkpatch/checkpatch.sh
@@ -269,7 +269,7 @@ ret=0
 for ((i=0; i<nb_commits; i++)); do
     sha=$(echo "$list_commits" | jq -r ".[$i].sha")
     subject=$(echo "$list_commits" | jq -r ".[$i].subject")
-    check_commit "$i" "$nb_commits" "$sha" "$subject" "$GITHUB_REF"
+    check_commit "$((i+1))" "$nb_commits" "$sha" "$subject" "$GITHUB_REF"
 done
 
 # If not a GitHub action and repo is dirty, run on diff from HEAD


### PR DESCRIPTION
Currently, the commit index reported as part of the commit list is off
by one, e.g. in an example from
https://github.com/cilium/cilium/pull/18247:

```
Retrieved 5 commits from PR #18247

{[0/5] option: correct godoc for (*DaemonConfig).TunnelingEnabled}
{[1/5] maps/tunnel: mark TunnelMap as NonPersistent on creation}
{[2/5] datapath, tunnel: correctly ignore ENOENT on tunnel mapping delete}
{[3/5] daemon: open or create tunnel map cache only if needed}
{[4/5] datapath/linux: don't attempt to delete old tunnel map entries on node addition}
```

See https://github.com/cilium/cilium/runs/4505300593?check_suite_focus=true

Fix this by passing the 1-based index, not the 0-based index to function
`check_commit`.