### PR TITLE
images: update alpine base image to 3.15

### DIFF
--- a/images/bpftool/Dockerfile
+++ b/images/bpftool/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:c1ba0665b6f9f012d014a642d9882f7c38bdf365@sha256:01c7c957e9b0fc200644996c6bedac297c98b81dea502a3bc3047837e67a7fcb
 ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:8bce67040cd0ae39e0beb55bcb976a824d9966d2ac8d2e4bf6119b45505cee64
-ARG TESTER_IMAGE=quay.io/cilium/image-tester:6316b0f5606a69078bed1dd9f9c2b5685fede3b0@sha256:f180855b1fb965e05dd02f57019e070569c4d7f2ef0f7bdaaa30bf3393a2ce7a
+ARG TESTER_IMAGE=quay.io/cilium/image-tester:2f8033eaf1c3e64b991e0ed44a570052778c55c7@sha256:f50a01c725e0183766b7e0c8fdff8b492d551bd5314daaa496106f2fde98a285
 
 FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder
 

--- a/images/ca-certificates/Dockerfile
+++ b/images/ca-certificates/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG ALPINE_BASE_IMAGE=docker.io/library/alpine:3.11@sha256:9a839e63dad54c3a6d1834e29692c8492d93f90c59c978c1ed79109ea4fb9a54
+ARG ALPINE_BASE_IMAGE=docker.io/library/alpine:3.15@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300
 
 FROM ${ALPINE_BASE_IMAGE} as builder
 

--- a/images/checkpatch/Dockerfile
+++ b/images/checkpatch/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2020 Authors of Cilium
 
-ARG ALPINE_BASE_IMAGE=docker.io/library/alpine:3.13.2@sha256:bef0a0cd630e965918669fb69250e91400d9e560a95b3e74b8e78d9d7ff5628e
+ARG ALPINE_BASE_IMAGE=docker.io/library/alpine:3.15@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300
 
 FROM ${ALPINE_BASE_IMAGE} as builder
 LABEL maintainer="maintainer@cilium.io"

--- a/images/compilers/Dockerfile
+++ b/images/compilers/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:8bce67040cd0ae39e0beb55bcb976a824d9966d2ac8d2e4bf6119b45505cee64
-ARG TESTER_IMAGE=quay.io/cilium/image-tester:6316b0f5606a69078bed1dd9f9c2b5685fede3b0@sha256:f180855b1fb965e05dd02f57019e070569c4d7f2ef0f7bdaaa30bf3393a2ce7a
+ARG TESTER_IMAGE=quay.io/cilium/image-tester:2f8033eaf1c3e64b991e0ed44a570052778c55c7@sha256:f50a01c725e0183766b7e0c8fdff8b492d551bd5314daaa496106f2fde98a285
 
 FROM ${UBUNTU_IMAGE} as builder
 

--- a/images/iproute2/Dockerfile
+++ b/images/iproute2/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:c1ba0665b6f9f012d014a642d9882f7c38bdf365@sha256:01c7c957e9b0fc200644996c6bedac297c98b81dea502a3bc3047837e67a7fcb
 ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:8bce67040cd0ae39e0beb55bcb976a824d9966d2ac8d2e4bf6119b45505cee64
-ARG TESTER_IMAGE=quay.io/cilium/image-tester:6316b0f5606a69078bed1dd9f9c2b5685fede3b0@sha256:f180855b1fb965e05dd02f57019e070569c4d7f2ef0f7bdaaa30bf3393a2ce7a
+ARG TESTER_IMAGE=quay.io/cilium/image-tester:2f8033eaf1c3e64b991e0ed44a570052778c55c7@sha256:f50a01c725e0183766b7e0c8fdff8b492d551bd5314daaa496106f2fde98a285
 
 FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder
 

--- a/images/llvm/Dockerfile
+++ b/images/llvm/Dockerfile
@@ -3,7 +3,7 @@
 
 ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:c1ba0665b6f9f012d014a642d9882f7c38bdf365@sha256:01c7c957e9b0fc200644996c6bedac297c98b81dea502a3bc3047837e67a7fcb
 ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:8bce67040cd0ae39e0beb55bcb976a824d9966d2ac8d2e4bf6119b45505cee64
-ARG TESTER_IMAGE=quay.io/cilium/image-tester:6316b0f5606a69078bed1dd9f9c2b5685fede3b0@sha256:f180855b1fb965e05dd02f57019e070569c4d7f2ef0f7bdaaa30bf3393a2ce7a
+ARG TESTER_IMAGE=quay.io/cilium/image-tester:2f8033eaf1c3e64b991e0ed44a570052778c55c7@sha256:f50a01c725e0183766b7e0c8fdff8b492d551bd5314daaa496106f2fde98a285
 
 FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder
 

--- a/images/maker/Dockerfile
+++ b/images/maker/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG DOCKER_IMAGE=docker.io/library/docker:19.03.8-dind@sha256:841b5eb000551dc3c30a46386ab4bfed5839ec9592c88e961236b25194ce88b9
 ARG CRANE_IMAGE=gcr.io/go-containerregistry/crane:latest@sha256:88335131ccc1f0687226245f68b0b328864026bc6504e97f4e1c130b5c766420
-ARG ALPINE_BASE_IMAGE=docker.io/library/alpine:3.11@sha256:9a839e63dad54c3a6d1834e29692c8492d93f90c59c978c1ed79109ea4fb9a54
+ARG ALPINE_BASE_IMAGE=docker.io/library/alpine:3.15@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300
 ARG GOLANG_IMAGE=docker.io/library/golang:1.17.5@sha256:eb61213fe612b6af346cab13c2b81f1b8113f9ccf23a5ca6b54fede8ffd63bc7
 
 FROM ${DOCKER_IMAGE} as docker-dist

--- a/images/startup-script/Dockerfile
+++ b/images/startup-script/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG ALPINE_BASE_IMAGE=docker.io/library/alpine:3.11@sha256:9a839e63dad54c3a6d1834e29692c8492d93f90c59c978c1ed79109ea4fb9a54
+ARG ALPINE_BASE_IMAGE=docker.io/library/alpine:3.15@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300
 
 FROM ${ALPINE_BASE_IMAGE} as builder
 

--- a/images/tester/Dockerfile
+++ b/images/tester/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG GOLANG_IMAGE=docker.io/library/golang:1.17.5@sha256:eb61213fe612b6af346cab13c2b81f1b8113f9ccf23a5ca6b54fede8ffd63bc7
-ARG ALPINE_BASE_IMAGE=docker.io/library/alpine:3.11@sha256:9a839e63dad54c3a6d1834e29692c8492d93f90c59c978c1ed79109ea4fb9a54
+ARG ALPINE_BASE_IMAGE=docker.io/library/alpine:3.15@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300
 
 FROM --platform=linux/amd64 ${GOLANG_IMAGE} as go-builder
 

--- a/scripts/update-alpine-base-image.sh
+++ b/scripts/update-alpine-base-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017-2020 Authors of Cilium
+# Copyright 2017-2021 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
 set -o xtrace
@@ -19,7 +19,7 @@ root_dir="$(git rev-parse --show-toplevel)"
 
 cd "${root_dir}"
 
-image="${1:-docker.io/library/alpine:3.11}"
+image="${1:-docker.io/library/alpine:3.15}"
 
 image_digest="$("${script_dir}/get-image-digest.sh" "${image}")"
 


### PR DESCRIPTION
Quay security scanner reports several vulnerabilities in the alpine 3.11
base image we currently use for images. Update to latest alpine 3.15 to
pull in fixes for these vulnerabilities.