### PR TITLE
images/tester: fix build after container-structure-test update

### DIFF
--- a/images/tester/cst/main.go
+++ b/images/tester/cst/main.go
@@ -83,7 +83,7 @@ func main() {
 		close(channel)
 	}()
 
-	if err := test.ProcessResults(os.Stdout, false, channel); err != nil {
+	if err := test.ProcessResults(os.Stdout, unversioned.Text, channel); err != nil {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
The bool arg to test.ProcessResults was changed upstream in
https://github.com/GoogleContainerTools/container-structure-test/pull/254

Fixes: 5cfd469de1b1 ("images/tester: update container-structure-test to latest version")