### PR TITLE
iproute2: update to latest libbpf-static-data

### DIFF
--- a/images/iproute2/checkout-iproute2.sh
+++ b/images/iproute2/checkout-iproute2.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-rev="b0f3a1a74ae45efd866b12476a4147de90f43ac6" # libbpf-static-data
+rev="9ee52f43f2fa4b2dfb655ec5247a3e8d16ada88c" # libbpf-static-data
 
 # git clone https://github.com/cilium/iproute2 /src/iproute2
 # cd /src/iproute2


### PR DESCRIPTION
This is needed to pick up a fix that sets the proper log level in libbpf, if a verbose flag is passed to tc and fix https://github.com/cilium/cilium/issues/18281.

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>