### PR TITLE
bpftool/test: update bpftool version

### DIFF
--- a/images/bpftool/test/spec.yaml
+++ b/images/bpftool/test/spec.yaml
@@ -15,4 +15,4 @@ commandTests:
   command: "bpftool"
   args: ["version"]
   expectedOutput:
-  - 'bpftool\ v5\.15\.0-rc3'
+  - 'bpftool\ v5\.16\.0-rc7'


### PR DESCRIPTION
CI test fails with:
> Error: Expected string 'bpftool\ v5\.15\.0-rc3' not found in output 'bpftool v5.16.0-rc7

Fix this by updating the bpftool version.

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>