### PR TITLE
Fix github workflow for network-perf

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -120,7 +120,7 @@ jobs:
           entrypoint: make
           args: test-verifier-image PUSH=true
       - uses: docker://quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a
-        name: Run make iperf3 
+        name: Run make network-perf-image 
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_CI }}
@@ -128,4 +128,4 @@ jobs:
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME_IMAGE_TOOLS }}
         with:
           entrypoint: make
-          args: iperf3-image PUSH=true
+          args: network-perf-image PUSH=true


### PR DESCRIPTION
- remove workflow/image entry for iperf3
- workflow/image entry was missing network-perf-image

Signed-off-by: Joe Talerico <rook@isovalent.com>