### PR TITLE
bpftool: Update to latest bpf-next

### DIFF
--- a/images/bpftool/checkout-linux.sh
+++ b/images/bpftool/checkout-linux.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-rev="5e22dd18626726028a93ff1350a8a71a00fd843d"
+rev="c344b9fc2108eeaa347c387219886cf87e520e93"
 
 # git clone git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git /src/linux
 # cd /src/linux

--- a/images/bpftool/test/spec.yaml
+++ b/images/bpftool/test/spec.yaml
@@ -15,4 +15,4 @@ commandTests:
   command: "bpftool"
   args: ["version"]
   expectedOutput:
-  - 'bpftool\ v5\.16\.0-rc7'
+  - 'bpftool\ v6\.8\.0'


### PR DESCRIPTION
The bpftool version currently used in the cilium-bpftool image seems to have a regression so trying to update.