### PR TITLE
bpftool: Update to latest bpf-next

### DIFF
--- a/images/bpftool/checkout-linux.sh
+++ b/images/bpftool/checkout-linux.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-rev="c344b9fc2108eeaa347c387219886cf87e520e93"
+rev="0f8619929c572609f7cdfa366d0424c2c2552e60"
 
 # git clone git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git /src/linux
 # cd /src/linux


### PR DESCRIPTION
The bpftool version currently used in the cilium-bpftool image cannot
probe for BBR availability.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>