### PR TITLE
Update maker-image to build for arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ update-ubuntu-image:
 	scripts/update-ubuntu-image.sh
 
 maker-image: .buildx_builder
-	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh image-maker images/maker linux/amd64 "$$(cat .buildx_builder)" $(REGISTRIES)
+	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh image-maker images/maker linux/amd64,linux/arm64 "$$(cat .buildx_builder)" $(REGISTRIES)
 
 update-maker-image:
 	scripts/update-maker-image.sh $(firstword $(REGISTRIES))

--- a/images/maker/Dockerfile
+++ b/images/maker/Dockerfile
@@ -7,6 +7,7 @@ ARG DOCKER_IMAGE=docker.io/library/docker:19.03.8-dind@sha256:841b5eb000551dc3c3
 ARG CRANE_IMAGE=gcr.io/go-containerregistry/crane:latest@sha256:88335131ccc1f0687226245f68b0b328864026bc6504e97f4e1c130b5c766420
 ARG ALPINE_BASE_IMAGE=docker.io/library/alpine:3.15@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300
 ARG GOLANG_IMAGE=docker.io/library/golang:1.18.1@sha256:12d3995156cb0dcdbb9d3edb5827e4e8e1bf5bf92436bfd12d696ec997001a9a
+ARG TARGETARCH
 
 FROM ${DOCKER_IMAGE} as docker-dist
 FROM ${CRANE_IMAGE} as crane-dist
@@ -32,21 +33,29 @@ RUN apk add --initdb --no-cache --root /out \
     coreutils \
     git \
     make \
-    shellcheck \
     jq \
     yq \
     && true
+
+# install shellcheck manually since alpine does not package it for ARM
+RUN if [[ "${TARGETARCH}" == "amd64" ]]; then SHELLCHECK_ARCH="x86_64"; else SHELLCHECK_ARCH="aarch64"; fi && \
+  curl --fail --show-error --silent --location \
+    https://github.com/koalaman/shellcheck/releases/download/v0.8.0/shellcheck-v0.8.0.linux.${SHELLCHECK_ARCH}.tar.xz \
+    --output /tmp/shellcheck.tar.xz && \
+  tar xf /tmp/shellcheck.tar.xz -C /usr/local --strip-components=1 && \
+  rm -rf /tmp/shellcheck.tar.xz
 
 COPY --from=docker-dist /usr/local/bin /out/usr/local/bin
 COPY --from=crane-dist /ko-app/crane /out/usr/local/bin/crane
 COPY --from=go-builder /out /out
 
-ARG HADOLINT_VERSION=1.17.6
+ARG HADOLINT_VERSION=2.10.0
 
-RUN curl --fail --show-error --silent --location \
-      https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64 \
+RUN if [[ "${TARGETARCH}" == "amd64" ]]; then HADOLINT_ARCH="x86_64"; else HADOLINT_ARCH="arm64"; fi && \
+  curl --fail --show-error --silent --location \
+    https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-${HADOLINT_ARCH} \
     --output /out/usr/local/bin/hadolint \
-    && chmod +x /out/usr/local/bin/hadolint
+  && chmod +x /out/usr/local/bin/hadolint
 
 RUN mkdir -p /out/etc/docker/cli-plugins \
     && echo '{ "experimental": "enabled", "credsStore" : "env" }' > /out/etc/docker/config.json \


### PR DESCRIPTION
~Step 1 for making the compiler image support arm64, which is required for tetragon to support arm64.~

I got mixed up and thought this was necessary to update the compilers image, but that one is dependent on the testers image. Oh well! Not sure how useful this is overall, but I'll leave that to others to decide.