### PR TITLE
bpftool: update to latest bpf-next

### DIFF
--- a/images/bpftool/checkout-linux.sh
+++ b/images/bpftool/checkout-linux.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-rev="0f8619929c572609f7cdfa366d0424c2c2552e60"
+rev="89eda98428ce10f8df110d60aa934aa5c5170686"
 
 # git clone git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git /src/linux
 # cd /src/linux

--- a/images/bpftool/test/spec.yaml
+++ b/images/bpftool/test/spec.yaml
@@ -15,4 +15,4 @@ commandTests:
   command: "bpftool"
   args: ["version"]
   expectedOutput:
-  - 'bpftool\ v6\.8\.0'
+  - 'bpftool\ v7\.0\.0'


### PR DESCRIPTION
Probing for BIG TCP support requires helpers that were added for kernel
5.19 so we need to udpate bpftool's image.

Signed-off-by: Nikolay Aleksandrov <nikolay@isovalent.com>