### PR TITLE
Revert "image: Bump all images to ubuntu LTS 22.04"

### DIFF
--- a/images/bpftool/Dockerfile
+++ b/images/bpftool/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:a990f3bb8b35b7abd54bd3c7d56ca68f8c7f6e2d@sha256:6859bc4ba2131b5cd2c2a2f5c635ad47485fcf1a0f9a90e0070903924d7e5e2f
-ARG UBUNTU_IMAGE=docker.io/library/ubuntu:22.04@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3322
 ARG TESTER_IMAGE=quay.io/cilium/image-tester:98852499bdc497763ace7f8d041ee09676a1d989@sha256:36bc12ded912c3a589df7b8846758968ccb00945bcd5ae6782cd45221652f840
 
 FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder

--- a/images/compilers/Dockerfile
+++ b/images/compilers/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG UBUNTU_IMAGE=docker.io/library/ubuntu:22.04@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3322
 ARG TESTER_IMAGE=quay.io/cilium/image-tester:98852499bdc497763ace7f8d041ee09676a1d989@sha256:36bc12ded912c3a589df7b8846758968ccb00945bcd5ae6782cd45221652f840
 
 FROM ${UBUNTU_IMAGE} as builder

--- a/images/compilers/install-deps.sh
+++ b/images/compilers/install-deps.sh
@@ -21,8 +21,8 @@ packages=(
   flex
   g++
   g++-aarch64-linux-gnu
-  gcc-9
-  gcc-9-aarch64-linux-gnu
+  gcc
+  gcc-aarch64-linux-gnu
   git
   libelf-dev
   libelf-dev:arm64
@@ -31,6 +31,7 @@ packages=(
   make
   ninja-build
   pkg-config
+  pkg-config-aarch64-linux-gnu
   python2
   python3
   python3-pip
@@ -40,14 +41,14 @@ packages=(
 export DEBIAN_FRONTEND=noninteractive
 
 cat > /etc/apt/sources.list << EOF
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main restricted universe multiverse
-deb [arch=amd64] http://security.ubuntu.com/ubuntu jammy-updates main restricted universe multiverse
-deb [arch=amd64] http://security.ubuntu.com/ubuntu jammy-security main restricted universe multiverse
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-backports main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ jammy main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ jammy-security main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ jammy-backports main restricted universe multiverse
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu focal main restricted universe multiverse
+deb [arch=amd64] http://security.ubuntu.com/ubuntu focal-updates main restricted universe multiverse
+deb [arch=amd64] http://security.ubuntu.com/ubuntu focal-security main restricted universe multiverse
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu focal-backports main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ focal main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ focal-updates main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ focal-security main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ focal-backports main restricted universe multiverse
 EOF
 
 dpkg --add-architecture arm64
@@ -59,5 +60,3 @@ ln -fs /usr/share/zoneinfo/UTC /etc/localtime
 apt-get install -y --no-install-recommends "${packages[@]}"
 
 update-alternatives --install /usr/bin/python python /usr/bin/python2 1
-update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 2
-update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-9 3

--- a/images/compilers/test/spec.yaml
+++ b/images/compilers/test/spec.yaml
@@ -10,7 +10,7 @@ commandTests:
   args: ["-v"]
   expectedError:
   - 'Target:\ x86_64-linux-gnu'
-  - 'gcc\ version\ 9\.4\.0'
+  - 'gcc\ version\ 9\.3\.0'
 - name: "aarch64-linux-gnu-gcc command is in path"
   command: "which"
   args: ["aarch64-linux-gnu-gcc"]
@@ -20,7 +20,7 @@ commandTests:
   args: ["-v"]
   expectedError:
   - 'Target:\ aarch64-linux-gnu'
-  - 'gcc\ version\ 9\.4\.0'
+  - 'gcc\ version\ 9\.3\.0'
 
 - name: "which bazel-3.7.0-linux-x86_64"
   command: "which"

--- a/images/iproute2/Dockerfile
+++ b/images/iproute2/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:a990f3bb8b35b7abd54bd3c7d56ca68f8c7f6e2d@sha256:6859bc4ba2131b5cd2c2a2f5c635ad47485fcf1a0f9a90e0070903924d7e5e2f
-ARG UBUNTU_IMAGE=docker.io/library/ubuntu:22.04@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3322
 ARG TESTER_IMAGE=quay.io/cilium/image-tester:98852499bdc497763ace7f8d041ee09676a1d989@sha256:36bc12ded912c3a589df7b8846758968ccb00945bcd5ae6782cd45221652f840
 
 FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder

--- a/images/llvm/Dockerfile
+++ b/images/llvm/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:a990f3bb8b35b7abd54bd3c7d56ca68f8c7f6e2d@sha256:6859bc4ba2131b5cd2c2a2f5c635ad47485fcf1a0f9a90e0070903924d7e5e2f
-ARG UBUNTU_IMAGE=docker.io/library/ubuntu:22.04@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3322
 ARG TESTER_IMAGE=quay.io/cilium/image-tester:98852499bdc497763ace7f8d041ee09676a1d989@sha256:36bc12ded912c3a589df7b8846758968ccb00945bcd5ae6782cd45221652f840
 
 FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder

--- a/scripts/update-ubuntu-image.sh
+++ b/scripts/update-ubuntu-image.sh
@@ -19,7 +19,7 @@ root_dir="$(git rev-parse --show-toplevel)"
 
 cd "${root_dir}"
 
-image="${1:-docker.io/library/ubuntu:22.04}"
+image="${1:-docker.io/library/ubuntu:20.04}"
 
 image_digest="$("${script_dir}/get-image-digest.sh" "${image}")"
 


### PR DESCRIPTION
This reverts commit a3c6a88e64eabde7a1acaf67992f229db1a0e053.

The new images based on Ubuntu 22.04 are failing Cilium's CI, so let's revert back temporarily so that not all dependency updates are blocked.