### PR TITLE
image: Bump all images to ubuntu LTS 22.04

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -9,17 +9,17 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
-      - uses: docker://quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a
+      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Register binfmt from multi-platform builds
         with:
           entrypoint: docker
           args: run --privileged linuxkit/binfmt:5d33e7346e79f9c13a73c6952669e47a53b063d4
-      - uses: docker://quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a
+      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Run make lint
         with:
-          entrypoint: make
-          args: lint
-      - uses: docker://quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a
+          entrypoint: sh
+          args: -c "git config --global --add safe.directory /github/workspace && make lint"
+      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Run make maker-image
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
@@ -27,9 +27,9 @@ jobs:
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD_IMAGE_TOOLS }}
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME_IMAGE_TOOLS }}
         with:
-          entrypoint: make
-          args: maker-image PUSH=true
-      - uses: docker://quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a
+          entrypoint: sh
+          args: -c "git config --global --add safe.directory /github/workspace && make maker-image PUSH=true"
+      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Run make tester-image
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
@@ -39,7 +39,7 @@ jobs:
         with:
           entrypoint: make
           args: tester-image PUSH=true
-      - uses: docker://quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a
+      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Run make compilers-image
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
@@ -49,7 +49,7 @@ jobs:
         with:
           entrypoint: make
           args: compilers-image PUSH=true
-      - uses: docker://quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a
+      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Run make bpftool-image
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
@@ -59,7 +59,7 @@ jobs:
         with:
           entrypoint: make
           args: bpftool-image PUSH=true
-      - uses: docker://quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a
+      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Run make iproute2-image
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
@@ -69,7 +69,7 @@ jobs:
         with:
           entrypoint: make
           args: iproute2-image PUSH=true
-      - uses: docker://quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a
+      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Run make llvm-image
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
@@ -79,7 +79,7 @@ jobs:
         with:
           entrypoint: make
           args: llvm-image PUSH=true
-      - uses: docker://quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a
+      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Run make startup-script-image
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
@@ -89,7 +89,7 @@ jobs:
         with:
           entrypoint: make
           args: startup-script-image PUSH=true
-      - uses: docker://quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a
+      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Run make ca-certificates-image
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
@@ -99,7 +99,7 @@ jobs:
         with:
           entrypoint: make
           args: ca-certificates-image PUSH=true
-      - uses: docker://quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a
+      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Run make checkpatch-image
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
@@ -109,7 +109,7 @@ jobs:
         with:
           entrypoint: make
           args: checkpatch-image PUSH=true
-      - uses: docker://quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a
+      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Run make test-verifier-image
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
@@ -119,7 +119,7 @@ jobs:
         with:
           entrypoint: make
           args: test-verifier-image PUSH=true
-      - uses: docker://quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a
+      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Run make network-perf-image 
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -13,7 +13,7 @@ jobs:
         name: Register binfmt from multi-platform builds
         with:
           entrypoint: docker
-          args: run --privileged linuxkit/binfmt:5d33e7346e79f9c13a73c6952669e47a53b063d4
+          args: run --privileged linuxkit/binfmt:a17941b47f5cb262638cfb49ffc59ac5ac2bf334
       - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Run make lint
         with:

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
-      - uses: docker://quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a
+      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Run make lint
         with:
-          entrypoint: make
-          args: lint
+          entrypoint: sh
+          args: -c "git config --global --add safe.directory /github/workspace && make lint"

--- a/images/bpftool/Dockerfile
+++ b/images/bpftool/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:c1ba0665b6f9f012d014a642d9882f7c38bdf365@sha256:01c7c957e9b0fc200644996c6bedac297c98b81dea502a3bc3047837e67a7fcb
+ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:5569a29cea6b3ad50aeb03102aaf3dc03841197c@sha256:b15dbedb7c49816c74a765e2f6ecdb9359763b8e4e4328d794f48b9cefae9804
 ARG UBUNTU_IMAGE=docker.io/library/ubuntu:22.04@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
 ARG TESTER_IMAGE=quay.io/cilium/image-tester:dd09c8d3ef349a909fbcdc99279516baef153f22@sha256:c056d064cb47c97acd607343db5457e1d49d9338d6d8a87e93e23cc93f052c73
 

--- a/images/bpftool/Dockerfile
+++ b/images/bpftool/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:c1ba0665b6f9f012d014a642d9882f7c38bdf365@sha256:01c7c957e9b0fc200644996c6bedac297c98b81dea502a3bc3047837e67a7fcb
 ARG UBUNTU_IMAGE=docker.io/library/ubuntu:22.04@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
-ARG TESTER_IMAGE=quay.io/cilium/image-tester:2f8033eaf1c3e64b991e0ed44a570052778c55c7@sha256:f50a01c725e0183766b7e0c8fdff8b492d551bd5314daaa496106f2fde98a285
+ARG TESTER_IMAGE=quay.io/cilium/image-tester:dd09c8d3ef349a909fbcdc99279516baef153f22@sha256:c056d064cb47c97acd607343db5457e1d49d9338d6d8a87e93e23cc93f052c73
 
 FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder
 

--- a/images/bpftool/Dockerfile
+++ b/images/bpftool/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:c1ba0665b6f9f012d014a642d9882f7c38bdf365@sha256:01c7c957e9b0fc200644996c6bedac297c98b81dea502a3bc3047837e67a7fcb
-ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3322
+ARG UBUNTU_IMAGE=docker.io/library/ubuntu:22.04@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
 ARG TESTER_IMAGE=quay.io/cilium/image-tester:2f8033eaf1c3e64b991e0ed44a570052778c55c7@sha256:f50a01c725e0183766b7e0c8fdff8b492d551bd5314daaa496106f2fde98a285
 
 FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder

--- a/images/compilers/Dockerfile
+++ b/images/compilers/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG UBUNTU_IMAGE=docker.io/library/ubuntu:22.04@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
-ARG TESTER_IMAGE=quay.io/cilium/image-tester:2f8033eaf1c3e64b991e0ed44a570052778c55c7@sha256:f50a01c725e0183766b7e0c8fdff8b492d551bd5314daaa496106f2fde98a285
+ARG TESTER_IMAGE=quay.io/cilium/image-tester:dd09c8d3ef349a909fbcdc99279516baef153f22@sha256:c056d064cb47c97acd607343db5457e1d49d9338d6d8a87e93e23cc93f052c73
 
 FROM ${UBUNTU_IMAGE} as builder
 

--- a/images/compilers/Dockerfile
+++ b/images/compilers/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3322
+ARG UBUNTU_IMAGE=docker.io/library/ubuntu:22.04@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
 ARG TESTER_IMAGE=quay.io/cilium/image-tester:2f8033eaf1c3e64b991e0ed44a570052778c55c7@sha256:f50a01c725e0183766b7e0c8fdff8b492d551bd5314daaa496106f2fde98a285
 
 FROM ${UBUNTU_IMAGE} as builder

--- a/images/compilers/install-deps.sh
+++ b/images/compilers/install-deps.sh
@@ -21,8 +21,8 @@ packages=(
   flex
   g++
   g++-aarch64-linux-gnu
-  gcc
-  gcc-aarch64-linux-gnu
+  gcc-9
+  gcc-9-aarch64-linux-gnu
   git
   libelf-dev
   libelf-dev:arm64
@@ -31,7 +31,6 @@ packages=(
   make
   ninja-build
   pkg-config
-  pkg-config-aarch64-linux-gnu
   python2
   python3
   python3-pip
@@ -41,14 +40,14 @@ packages=(
 export DEBIAN_FRONTEND=noninteractive
 
 cat > /etc/apt/sources.list << EOF
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu focal main restricted universe multiverse
-deb [arch=amd64] http://security.ubuntu.com/ubuntu focal-updates main restricted universe multiverse
-deb [arch=amd64] http://security.ubuntu.com/ubuntu focal-security main restricted universe multiverse
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu focal-backports main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ focal main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ focal-updates main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ focal-security main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ focal-backports main restricted universe multiverse
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main restricted universe multiverse
+deb [arch=amd64] http://security.ubuntu.com/ubuntu jammy-updates main restricted universe multiverse
+deb [arch=amd64] http://security.ubuntu.com/ubuntu jammy-security main restricted universe multiverse
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-backports main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ jammy main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ jammy-security main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ jammy-backports main restricted universe multiverse
 EOF
 
 dpkg --add-architecture arm64
@@ -60,3 +59,5 @@ ln -fs /usr/share/zoneinfo/UTC /etc/localtime
 apt-get install -y --no-install-recommends "${packages[@]}"
 
 update-alternatives --install /usr/bin/python python /usr/bin/python2 1
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 2
+update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-9 3

--- a/images/compilers/test/spec.yaml
+++ b/images/compilers/test/spec.yaml
@@ -10,7 +10,7 @@ commandTests:
   args: ["-v"]
   expectedError:
   - 'Target:\ x86_64-linux-gnu'
-  - 'gcc\ version\ 9\.3\.0'
+  - 'gcc\ version\ 9\.4\.0'
 - name: "aarch64-linux-gnu-gcc command is in path"
   command: "which"
   args: ["aarch64-linux-gnu-gcc"]
@@ -20,7 +20,7 @@ commandTests:
   args: ["-v"]
   expectedError:
   - 'Target:\ aarch64-linux-gnu'
-  - 'gcc\ version\ 9\.3\.0'
+  - 'gcc\ version\ 9\.4\.0'
 
 - name: "which bazel-3.7.0-linux-x86_64"
   command: "which"

--- a/images/iproute2/Dockerfile
+++ b/images/iproute2/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:c1ba0665b6f9f012d014a642d9882f7c38bdf365@sha256:01c7c957e9b0fc200644996c6bedac297c98b81dea502a3bc3047837e67a7fcb
+ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:5569a29cea6b3ad50aeb03102aaf3dc03841197c@sha256:b15dbedb7c49816c74a765e2f6ecdb9359763b8e4e4328d794f48b9cefae9804
 ARG UBUNTU_IMAGE=docker.io/library/ubuntu:22.04@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
 ARG TESTER_IMAGE=quay.io/cilium/image-tester:dd09c8d3ef349a909fbcdc99279516baef153f22@sha256:c056d064cb47c97acd607343db5457e1d49d9338d6d8a87e93e23cc93f052c73
 

--- a/images/iproute2/Dockerfile
+++ b/images/iproute2/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:c1ba0665b6f9f012d014a642d9882f7c38bdf365@sha256:01c7c957e9b0fc200644996c6bedac297c98b81dea502a3bc3047837e67a7fcb
 ARG UBUNTU_IMAGE=docker.io/library/ubuntu:22.04@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
-ARG TESTER_IMAGE=quay.io/cilium/image-tester:2f8033eaf1c3e64b991e0ed44a570052778c55c7@sha256:f50a01c725e0183766b7e0c8fdff8b492d551bd5314daaa496106f2fde98a285
+ARG TESTER_IMAGE=quay.io/cilium/image-tester:dd09c8d3ef349a909fbcdc99279516baef153f22@sha256:c056d064cb47c97acd607343db5457e1d49d9338d6d8a87e93e23cc93f052c73
 
 FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder
 

--- a/images/iproute2/Dockerfile
+++ b/images/iproute2/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:c1ba0665b6f9f012d014a642d9882f7c38bdf365@sha256:01c7c957e9b0fc200644996c6bedac297c98b81dea502a3bc3047837e67a7fcb
-ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3322
+ARG UBUNTU_IMAGE=docker.io/library/ubuntu:22.04@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
 ARG TESTER_IMAGE=quay.io/cilium/image-tester:2f8033eaf1c3e64b991e0ed44a570052778c55c7@sha256:f50a01c725e0183766b7e0c8fdff8b492d551bd5314daaa496106f2fde98a285
 
 FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder

--- a/images/llvm/Dockerfile
+++ b/images/llvm/Dockerfile
@@ -3,7 +3,7 @@
 
 ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:c1ba0665b6f9f012d014a642d9882f7c38bdf365@sha256:01c7c957e9b0fc200644996c6bedac297c98b81dea502a3bc3047837e67a7fcb
 ARG UBUNTU_IMAGE=docker.io/library/ubuntu:22.04@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
-ARG TESTER_IMAGE=quay.io/cilium/image-tester:2f8033eaf1c3e64b991e0ed44a570052778c55c7@sha256:f50a01c725e0183766b7e0c8fdff8b492d551bd5314daaa496106f2fde98a285
+ARG TESTER_IMAGE=quay.io/cilium/image-tester:dd09c8d3ef349a909fbcdc99279516baef153f22@sha256:c056d064cb47c97acd607343db5457e1d49d9338d6d8a87e93e23cc93f052c73
 
 FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder
 

--- a/images/llvm/Dockerfile
+++ b/images/llvm/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:c1ba0665b6f9f012d014a642d9882f7c38bdf365@sha256:01c7c957e9b0fc200644996c6bedac297c98b81dea502a3bc3047837e67a7fcb
-ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3322
+ARG UBUNTU_IMAGE=docker.io/library/ubuntu:22.04@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
 ARG TESTER_IMAGE=quay.io/cilium/image-tester:2f8033eaf1c3e64b991e0ed44a570052778c55c7@sha256:f50a01c725e0183766b7e0c8fdff8b492d551bd5314daaa496106f2fde98a285
 
 FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder

--- a/images/llvm/Dockerfile
+++ b/images/llvm/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:c1ba0665b6f9f012d014a642d9882f7c38bdf365@sha256:01c7c957e9b0fc200644996c6bedac297c98b81dea502a3bc3047837e67a7fcb
+ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:5569a29cea6b3ad50aeb03102aaf3dc03841197c@sha256:b15dbedb7c49816c74a765e2f6ecdb9359763b8e4e4328d794f48b9cefae9804
 ARG UBUNTU_IMAGE=docker.io/library/ubuntu:22.04@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
 ARG TESTER_IMAGE=quay.io/cilium/image-tester:dd09c8d3ef349a909fbcdc99279516baef153f22@sha256:c056d064cb47c97acd607343db5457e1d49d9338d6d8a87e93e23cc93f052c73
 

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -7,7 +7,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-MAKER_IMAGE="${MAKER_IMAGE:-quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a}"
+MAKER_IMAGE="${MAKER_IMAGE:-quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de}"
 
 with_root_context="${ROOT_CONTEXT:-false}"
 

--- a/scripts/get-image-digest.sh
+++ b/scripts/get-image-digest.sh
@@ -7,7 +7,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-MAKER_IMAGE="${MAKER_IMAGE:-quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a}"
+MAKER_IMAGE="${MAKER_IMAGE:-quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de}"
 
 if [ "$#" -ne 1 ] ; then
   echo "$0 supports exactly 1 argument"

--- a/scripts/get-image-digest.sh
+++ b/scripts/get-image-digest.sh
@@ -17,7 +17,8 @@ fi
 root_dir="$(git rev-parse --show-toplevel)"
 
 if [ -z "${MAKER_CONTAINER+x}" ] ; then
-   exec docker run --env DOCKER_HUB_PUBLIC_ACCESS_ONLY=true --env QUAY_PUBLIC_ACCESS_ONLY=true --rm --volume "${root_dir}:/src" --workdir /src "${MAKER_IMAGE}" "/src/scripts/$(basename "${0}")" "${1}"
+   exec docker run --env DOCKER_HUB_PUBLIC_ACCESS_ONLY=true --env QUAY_PUBLIC_ACCESS_ONLY=true --rm --volume "${root_dir}:/src" --workdir /src "${MAKER_IMAGE}" \
+    sh -c "git config --global --add safe.directory /src && /src/scripts/$(basename "${0}") \"${1}\""
 fi
 
 crane digest "${1}" 2> /dev/null

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -7,12 +7,13 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-MAKER_IMAGE="${MAKER_IMAGE:-quay.io/cilium/image-maker:9e2e7ad1a524cf714d491945e90fe650125cd60a}"
+MAKER_IMAGE="${MAKER_IMAGE:-quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de}"
 
 root_dir="$(git rev-parse --show-toplevel)"
 
 if [ -z "${MAKER_CONTAINER+x}" ] ; then
-   exec docker run --rm --volume "${root_dir}:/src" --workdir /src "${MAKER_IMAGE}" "/src/scripts/$(basename "${0}")"
+   exec docker run --rm --volume "${root_dir}:/src" --workdir /src "${MAKER_IMAGE}" \
+    sh -c "git config --global --add safe.directory /src && /src/scripts/$(basename "${0}")"
 fi
 
 cd "${root_dir}"

--- a/scripts/update-ubuntu-image.sh
+++ b/scripts/update-ubuntu-image.sh
@@ -19,7 +19,7 @@ root_dir="$(git rev-parse --show-toplevel)"
 
 cd "${root_dir}"
 
-image="${1:-docker.io/library/ubuntu:20.04}"
+image="${1:-docker.io/library/ubuntu:22.04}"
 
 image_digest="$("${script_dir}/get-image-digest.sh" "${image}")"
 


### PR DESCRIPTION
### Description

This commit is to bump all images to the latest ubuntu LTS 22.04.

Signed-off-by: Tam Mach <tam.mach@cilium.io>

### Testing

Testing was done with temp commit, which was removed after.

https://github.com/cilium/image-tools/runs/7857674066?check_suite_focus=true