### PR TITLE
Enable network-perf for linux/arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,4 +63,4 @@ test-verifier-image: .buildx_builder
 	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh test-verifier images/test-verifier linux/amd64 "$$(cat .buildx_builder)" $(REGISTRIES)
 
 network-perf-image: .buildx_builder
-	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh network-perf images/network-perf linux/amd64 "$$(cat .buildx_builder)" $(REGISTRIES)
+	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh network-perf images/network-perf linux/amd64,linux/arm64 "$$(cat .buildx_builder)" $(REGISTRIES)

--- a/images/network-perf/Dockerfile
+++ b/images/network-perf/Dockerfile
@@ -3,13 +3,13 @@ COPY appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs make --enablerepo=centos9 --allowerasing
 RUN dnf install -y --nodocs gcc --enablerepo=centos9 --allowerasing
 RUN curl -L -o iperf.tar.gz https://github.com/esnet/iperf/archive/refs/tags/3.12.tar.gz
+RUN curl -L -o netperf.tar.gz https://github.com/HewlettPackard/netperf/archive/80bf19d563eebd1eca23f4092f96819296020fa5.tar.gz
 RUN mkdir /iperf && tar xzf iperf.tar.gz --strip-components=1 -C /iperf
-RUN curl -LO https://github.com/HewlettPackard/netperf/archive/refs/tags/netperf-2.7.0.tar.gz
-RUN tar -xzf netperf-2.7.0.tar.gz
+RUN mkdir /netperf && tar xzf netperf.tar.gz --strip-components=1 -C /netperf
 WORKDIR /iperf
 RUN ./configure && make && make install
-WORKDIR /netperf-netperf-2.7.0
+WORKDIR /netperf
 RUN ./configure && make && make install
 RUN rm -rf /iperf /iperf.tar.gz
-RUN rm -rf /netperf-2.7.0.tar.gz /netperf-netperf-2.7.0
+RUN rm -rf /netperf /netperf.tar.gz
 RUN dnf remove -y gcc make

--- a/images/network-perf/Dockerfile
+++ b/images/network-perf/Dockerfile
@@ -2,14 +2,14 @@ FROM registry.access.redhat.com/ubi8:8.6
 COPY appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs make --enablerepo=centos9 --allowerasing
 RUN dnf install -y --nodocs gcc --enablerepo=centos9 --allowerasing
+RUN curl -L -o iperf.tar.gz https://github.com/esnet/iperf/archive/refs/tags/3.12.tar.gz
+RUN mkdir /iperf && tar xzf iperf.tar.gz --strip-components=1 -C /iperf
 RUN curl -LO https://github.com/HewlettPackard/netperf/archive/refs/tags/netperf-2.7.0.tar.gz
-RUN curl -LO https://github.com/esnet/iperf/archive/refs/tags/3.11.tar.gz
-RUN tar -xzf 3.11.tar.gz
 RUN tar -xzf netperf-2.7.0.tar.gz
-WORKDIR /iperf-3.11
+WORKDIR /iperf
 RUN ./configure && make && make install
 WORKDIR /netperf-netperf-2.7.0
 RUN ./configure && make && make install
-RUN rm -rf /iperf-3.11 /3.11.tar.gz
+RUN rm -rf /iperf /iperf.tar.gz
 RUN rm -rf /netperf-2.7.0.tar.gz /netperf-netperf-2.7.0
 RUN dnf remove -y gcc make

--- a/images/network-perf/Dockerfile
+++ b/images/network-perf/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8:8.5
+FROM registry.access.redhat.com/ubi8:8.6
 COPY appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs make --enablerepo=centos9 --allowerasing
 RUN dnf install -y --nodocs gcc --enablerepo=centos9 --allowerasing


### PR DESCRIPTION
The image used in `cilium connectivity test --perf` is `quay.io/cilium/network-perf` which is
only compiled for `linux/amd64` and is not available for `linux/arm64`.

Here we propose:
 * bump the base image used for `network-perf` to `ubi8:8.6`
 * bump the `iperf` tool to 3.12
 * fetch the `netperf` from this tag https://github.com/HewlettPackard/netperf/commit/80bf19d563eebd1eca23f4092f96819296020fa5 to allow for arm64 builds
 * have a slightly better handling of the archive and folder names to allow easier version bumps when needed
 * enable `linux/arm64` builds for `network-perf`

