### PR TITLE
Add iptables builder image

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -129,3 +129,13 @@ jobs:
         with:
           entrypoint: make
           args: network-perf-image PUSH=true
+      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
+        name: Run make iptables-image
+        env:
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_CI }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD_IMAGE_TOOLS }}
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME_IMAGE_TOOLS }}
+        with:
+          entrypoint: make
+          args: iptables-image PUSH=true

--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,6 @@ test-verifier-image: .buildx_builder
 
 network-perf-image: .buildx_builder
 	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh network-perf images/network-perf linux/amd64,linux/arm64 "$$(cat .buildx_builder)" $(REGISTRIES)
+
+iptables-image: .buildx_builder
+	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh iptables images/iptables linux/amd64,linux/arm64 "$$(cat .buildx_builder)" $(REGISTRIES)

--- a/images/iptables/Dockerfile
+++ b/images/iptables/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+ARG IPTABLES_VERSION=1.8.8-1
+
+FROM docker.io/library/ubuntu:22.04@sha256:27cb6e6ccef575a4698b66f5de06c7ecd61589132d5a91d098f7f3f9285415a9
+
+RUN mkdir /iptables
+WORKDIR /iptables
+
+ARG IPTABLES_VERSION
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends debian-archive-keyring apt-src && \
+    echo 'deb-src [signed-by=/usr/share/keyrings/debian-archive-bullseye-automatic.gpg] http://deb.debian.org/debian bookworm main' > /etc/apt/sources.list.d/debian-testing.list && \
+    apt-get update && \
+    apt-src -b install iptables=${IPTABLES_VERSION} && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This image is used to build iptables deb packages from source (currently version 1.8.8-1), which will then be imported in the cilium-runtime image.