### PR TITLE
Build iptables using snapshots, for Ubuntu 20.04 and 22.04

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -139,3 +139,13 @@ jobs:
         with:
           entrypoint: make
           args: iptables-image PUSH=true
+      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
+        name: Run make iptables-20.04-image
+        env:
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_CI }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD_IMAGE_TOOLS }}
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME_IMAGE_TOOLS }}
+        with:
+          entrypoint: make
+          args: iptables-20.04-image PUSH=true

--- a/Makefile
+++ b/Makefile
@@ -67,3 +67,6 @@ network-perf-image: .buildx_builder
 
 iptables-image: .buildx_builder
 	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh iptables images/iptables linux/amd64,linux/arm64 "$$(cat .buildx_builder)" $(REGISTRIES)
+
+iptables-20.04-image: .buildx_builder
+	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh iptables-20.04 images/iptables-20.04 linux/amd64,linux/arm64 "$$(cat .buildx_builder)" $(REGISTRIES)

--- a/images/iptables-20.04/Dockerfile
+++ b/images/iptables-20.04/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+# This file builds iptables 1.8.8-1 from source using Ubuntu 20.04
+# The source code comes from Debian Bookworm snapshots
+# To upgrade to a new iptables version, change also the snapshot date.
+
+ARG IPTABLES_VERSION=1.8.8-1
+ARG SNAPSHOT_DATE=20230116T212610Z
+
+FROM docker.io/library/ubuntu:20.04@sha256:0e0402cd13f68137edb0266e1d2c682f217814420f2d43d300ed8f65479b14fb
+
+RUN mkdir /iptables
+WORKDIR /iptables
+
+ARG IPTABLES_VERSION
+ARG SNAPSHOT_DATE
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends debian-archive-keyring apt-src ca-certificates && \
+    echo 'deb [signed-by=/usr/share/keyrings/debian-archive-buster-automatic.gpg] http://deb.debian.org/debian bullseye main' > /etc/apt/sources.list.d/debian-bullseye.list && \
+    apt-get update && \
+    echo "deb-src [check-valid-until=no signed-by=/usr/share/keyrings/debian-archive-bullseye-automatic.gpg] https://snapshot.debian.org/archive/debian/${SNAPSHOT_DATE}/ bookworm main" > /etc/apt/sources.list.d/iptables-snapshot.list && \
+    apt-get update && \
+    apt-src -b install iptables=${IPTABLES_VERSION} && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/images/iptables/Dockerfile
+++ b/images/iptables/Dockerfile
@@ -1,7 +1,12 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
+# This file builds iptables 1.8.8-1 from source using Ubuntu 22.04
+# The source code comes from Debian Bookworm snapshots
+# To upgrade to a new iptables version, change also the snapshot date.
+
 ARG IPTABLES_VERSION=1.8.8-1
+ARG SNAPSHOT_DATE=20230116T212610Z
 
 FROM docker.io/library/ubuntu:22.04@sha256:27cb6e6ccef575a4698b66f5de06c7ecd61589132d5a91d098f7f3f9285415a9
 
@@ -9,10 +14,11 @@ RUN mkdir /iptables
 WORKDIR /iptables
 
 ARG IPTABLES_VERSION
+ARG SNAPSHOT_DATE
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends debian-archive-keyring apt-src && \
-    echo 'deb-src [signed-by=/usr/share/keyrings/debian-archive-bullseye-automatic.gpg] http://deb.debian.org/debian bookworm main' > /etc/apt/sources.list.d/debian-testing.list && \
+    apt-get install -y --no-install-recommends debian-archive-keyring apt-src ca-certificates && \
+    echo "deb-src [check-valid-until=no signed-by=/usr/share/keyrings/debian-archive-bullseye-automatic.gpg] https://snapshot.debian.org/archive/debian/${SNAPSHOT_DATE}/ bookworm main" > /etc/apt/sources.list.d/iptables-snapshot.list && \
     apt-get update && \
     apt-src -b install iptables=${IPTABLES_VERSION} && \
     apt-get clean && \


### PR DESCRIPTION
This change adds a new iptables-20.04 that builds the selected iptables version (1.8.8 in this case) for Ubuntu 20.04.

Additionally, instead of building from whatever is currently Debian testing, it uses the Debian snapshot infrastructure, to build a specific version, so that the Dockerfile won't break in the future.

If we want to change the version to a different one, we can do that by picking a future date.

I have tested that these two images build successfully and the output can be used to install iptables in the v1.13 and v1.12 branches respectively.