### PR TITLE
checkpatch: Ignore BIT_MACRO check reports

### DIFF
--- a/images/checkpatch/checkpatch.sh
+++ b/images/checkpatch/checkpatch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2020-2021 Authors of Cilium
+# Copyright Authors of Cilium
 
 # Default options for checkpatch
 options=(
@@ -34,6 +34,7 @@ ignore_list=(
     TRAILING_STATEMENTS
     VOLATILE
     # Checks
+    BIT_MACRO
     LONG_LINE_COMMENT
     # Ignore tolerance that comes by default
     C99_COMMENT_TOLERANCE


### PR DESCRIPTION
Checkpatch CI workflow has failed in the past with:

    BIT_MACRO: Prefer using the BIT macro

Although it is recommended to use this macro in kernel code, we do not use it (or have it defined) in Cilium's BPF code. This check is not relevant for us, so let's disable it.

Copyright years in header are not up-to-date, remove years altogether.
