### PR TITLE
llvm: Cherry-pick the 64-bit stack alignment patch

### DIFF
--- a/images/llvm/checkout-llvm.sh
+++ b/images/llvm/checkout-llvm.sh
@@ -18,6 +18,7 @@ git clone --branch "${rev}" https://github.com/llvm/llvm-project.git /src/llvm
 cd /src/llvm
 git cherry-pick 29bc5dd19407c4d7cad1c059dea26ee216ddc7ca
 git cherry-pick 13f6c81c5d9a7a34a684363bcaad8eb7c65356fd
+git cherry-pick ea72b0319d7b0f0c2fcf41d121afa5d031b319d5
 cd -
 
 # curl --fail --show-error --silent --location "https://github.com/llvm/llvm-project/archive/${rev}.tar.gz" --output /tmp/llvm.tgz


### PR DESCRIPTION
Cherry-pick the upstream LLVM commit ea72b0319d7b ("BPF: make 32bit register spill with 64bit alignment"). Since the upstream kernel commit 354e8f1970f8 ("bpf: Support <8-byte scalar spill and refill"), the kernel assumes that 32-bit spilled registers have 64-bit alignment on the stack, otherwise the verifier can't preserve the boundaries and can generate false positives.

Although this patch alone is not enough to fix the root cause of the issue that appeared in Cilium before Cilium commit efb5d6509fea ("bpf: Fix verifier issue in fib_redirect") worked around it, it's the first step that may also help in some other cases.