### PR TITLE
Nit: multiarch `checkpatch`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ startup-script-image: .buildx_builder
 	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh startup-script images/startup-script linux/amd64,linux/arm64 "$$(cat .buildx_builder)" $(REGISTRIES)
 
 checkpatch-image: .buildx_builder
-	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh cilium-checkpatch images/checkpatch linux/amd64 "$$(cat .buildx_builder)" $(REGISTRIES)
+	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh cilium-checkpatch images/checkpatch linux/amd64,linux/arm64 "$$(cat .buildx_builder)" $(REGISTRIES)
 
 test-verifier-image: .buildx_builder
 	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh test-verifier images/test-verifier linux/amd64 "$$(cat .buildx_builder)" $(REGISTRIES)


### PR DESCRIPTION
`checkpatch` should run on/have a multiarch image for arm64 linux boxes (like mine).