### PR TITLE
checkpatch: Add root .gitconfig

### DIFF
--- a/images/checkpatch/Dockerfile
+++ b/images/checkpatch/Dockerfile
@@ -7,6 +7,7 @@ ARG ALPINE_BASE_IMAGE=docker.io/library/alpine:3.18.0@sha256:02bb6f428431fbc2809
 FROM ${ALPINE_BASE_IMAGE} as builder
 LABEL maintainer="maintainer@cilium.io"
 
+COPY gitconfig /.gitconfig
 COPY . /checkpatch
 
 RUN apk add --no-cache bash curl git jq moreutils patch perl

--- a/images/checkpatch/gitconfig
+++ b/images/checkpatch/gitconfig
@@ -1,0 +1,2 @@
+[safe]
+	directory = *


### PR DESCRIPTION
Add root .gitconfig which sets all directories as safe. This prevents git failure when running on volumes mounted on macOS, for example (which show root as the owner within the container, see https://github.com/docker/for-mac/issues/2657).

Since checkpatch image is intended to be used with a Cilium repo mounted on a root directory (e.g., '/workspace') there is no risk of other users having untrusted '.git/config' files between '/.gitconfig' (added in this commit), and '/workspace/.git/config' (mounted from the Cilium repository), so there is no risk running malicious commands as speculated in
https://github.blog/2022-04-12-git-security-vulnerability-announced/#cve-2022-24765.