### PR TITLE
checkpatch: Ignore macro arg reuse by default

### DIFF
--- a/images/checkpatch/checkpatch.sh
+++ b/images/checkpatch/checkpatch.sh
@@ -36,6 +36,7 @@ ignore_list=(
     # Checks
     BIT_MACRO
     LONG_LINE_COMMENT
+    MACRO_ARG_REUSE
     # Ignore tolerance that comes by default
     C99_COMMENT_TOLERANCE
 )


### PR DESCRIPTION
cilium/cilium has ignored MACRO_ARG_REUSE since
https://github.com/cilium/cilium/pull/25284, update the default ignores so that this does not need to be explicitly added in cilium/cilium any more.