### PR TITLE
Revert "Cherry pick commit for kfunc support"

### DIFF
--- a/images/llvm/checkout-llvm.sh
+++ b/images/llvm/checkout-llvm.sh
@@ -19,7 +19,6 @@ cd /src/llvm
 git cherry-pick 29bc5dd19407c4d7cad1c059dea26ee216ddc7ca
 git cherry-pick 13f6c81c5d9a7a34a684363bcaad8eb7c65356fd
 git cherry-pick ea72b0319d7b0f0c2fcf41d121afa5d031b319d5
-git cherry-pick 886f9ff53155075bd5f1e994f17b85d1e1b7470c
 cd -
 
 # curl --fail --show-error --silent --location "https://github.com/llvm/llvm-project/archive/${rev}.tar.gz" --output /tmp/llvm.tgz


### PR DESCRIPTION
Alas, we are finally hitting merge conflicts.

```
CONFLICT (content): Merge conflict in llvm/lib/Target/BPF/BTFDebug.cpp
warning: inexact rename detection was skipped due to too many files. 
warning: you may want to set your merge.renamelimit variable to at least 20590 and retry the command.
error: could not apply 886f9ff53155... BPF: add extern func to data sections if specified
```

I've started an internal thread to discuss the conflicts.