### PR TITLE
Cherry pick commit for kfunc support (take #2)

### DIFF
--- a/images/llvm/checkout-llvm.sh
+++ b/images/llvm/checkout-llvm.sh
@@ -19,6 +19,9 @@ cd /src/llvm
 git cherry-pick 29bc5dd19407c4d7cad1c059dea26ee216ddc7ca
 git cherry-pick 13f6c81c5d9a7a34a684363bcaad8eb7c65356fd
 git cherry-pick ea72b0319d7b0f0c2fcf41d121afa5d031b319d5
+# Suppress git warning: inexact rename detection was skipped due to too many files. 
+git config merge.renamelimit 20591
+git cherry-pick 886f9ff53155075bd5f1e994f17b85d1e1b7470c
 cd -
 
 # curl --fail --show-error --silent --location "https://github.com/llvm/llvm-project/archive/${rev}.tar.gz" --output /tmp/llvm.tgz


### PR DESCRIPTION
As indicated in the kernel patch set -
https://lore.kernel.org/bpf/20210325015234.1548923-1-kafai@fb.com/, cherry pick - https://github.com/llvm/llvm-project/commit/886f9ff53155075bd5f1e994f17b85d1e1b7470c.

2nd time is the charm...?