### PR TITLE
checkpatch: Remove grouping logs in GHA output

### DIFF
--- a/images/checkpatch/checkpatch.sh
+++ b/images/checkpatch/checkpatch.sh
@@ -132,15 +132,10 @@ check_commit() {
     subject="$4"
     gh_action="$5"
 
-    if [ -n "$gh_action" ]; then
-        echo "::group::{[$i/$nb_commits] $subject}"
-        echo "Running on $sha"
-    else
-        echo "========================================================="
-        echo "[$i/$nb_commits] Running on $sha"
-        echo -e "$HL_START$subject$HL_END"
-        echo "========================================================="
-    fi
+    echo "========================================================="
+    echo "[$i/$nb_commits] Running on $sha"
+    echo -e "$HL_START$subject$HL_END"
+    echo "========================================================="
     # Recompute list of source files each time in case commit changes it
     update_sources
     (
@@ -166,9 +161,6 @@ check_commit() {
     ) || ret=1
     # Apply custom checks on all commits, whether or not they touch bpf/
     custom_checks "$sha" "$subject" "$gh_action"
-    if [ -n "$gh_action" ]; then
-        echo "::endgroup::"
-    fi
 }
 
 all_code=0


### PR DESCRIPTION
Grouping logs by commit in the output of the GitHub workflow provides a nicer interface than just displaying separators, but it turns out to be more cumbersome in case of errors, because users have no way to know what group contains the error and they have to manually expand all groups, which has proved annoying. There doesn't seem to be an option to auto-expand the groups, so let's remove them altogether.