### PR TITLE
llvm: Upgrade to LLVM 17.0.6

### DIFF
--- a/images/llvm/checkout-llvm.sh
+++ b/images/llvm/checkout-llvm.sh
@@ -8,18 +8,12 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-rev="llvmorg-10.0.0"
+rev="llvmorg-17.0.6"
 
 git config --global user.email "maintainer@cilium.io"
 git config --global user.name  "Cilium Maintainers"
 
 git clone --branch "${rev}" https://github.com/llvm/llvm-project.git /src/llvm
-
-cd /src/llvm
-git cherry-pick 29bc5dd19407c4d7cad1c059dea26ee216ddc7ca
-git cherry-pick 13f6c81c5d9a7a34a684363bcaad8eb7c65356fd
-git cherry-pick ea72b0319d7b0f0c2fcf41d121afa5d031b319d5
-cd -
 
 # curl --fail --show-error --silent --location "https://github.com/llvm/llvm-project/archive/${rev}.tar.gz" --output /tmp/llvm.tgz
 #


### PR DESCRIPTION
Fixes for Clang 17 were merged into the Cilium codebase:

b91046955d6b ("datapath: Ignore new debug ELF prefixes")
6e18eb020b68 ("bpf: Fix compatibility with Clang 17 in __lb6_affinity_backend_id")
3740e9db8fef ("bpf: Fix "R2 !read_ok" verifier error with LLVM 17")

and the complexity measurements were performed, so now the LLVM image can be upgraded.