### PR TITLE
checkpatch: Fix checkpatch.pl permissions

### DIFF
--- a/images/checkpatch/Dockerfile
+++ b/images/checkpatch/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache bash curl git jq moreutils patch perl
 RUN \
     curl -sSL --output /checkpatch/checkpatch.pl \
         "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/scripts/checkpatch.pl?h=${CHECKPATCH_VERSION}" && \
-    chmod u+x /checkpatch/checkpatch.pl && \
+    chmod a+x /checkpatch/checkpatch.pl && \
     curl -sSL --output /checkpatch/spelling.txt \
         "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/scripts/spelling.txt?h=${CHECKPATCH_VERSION}"
 


### PR DESCRIPTION
The latest checkpatch images complain:

    /checkpatch/checkpatch.sh: line 155: /checkpatch/checkpatch.pl: Permission denied

Let's fix the permissions for the script we download.

Fixes: e2a7f29cbf2e