### PR TITLE
renovate: pin ubuntu versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,22 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "ubuntu"
+      ],
+      "allowedVersions": "22.04"
+    },
+    {
+      "matchPaths": [
+        "images/iptables-20.04/Dockerfile"
+      ],
+      "matchPackageNames": [
+        "ubuntu"
+      ],
+      "allowedVersions": "20.04"
+    }
   ]
 }


### PR DESCRIPTION
pin all ubuntu versions to 22.04, expect images/iptables-20.04/Dockerfile which needs 20.04