### PR TITLE
startup-script: Adjust ca-certificates install to only copy certs

### DIFF
--- a/images/startup-script/Dockerfile
+++ b/images/startup-script/Dockerfile
@@ -9,12 +9,15 @@ RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 
 RUN apk add --initdb --no-cache --root /out \
     bash \
-    ca-certificates \
     util-linux \
     && true
 
 COPY manage-startup-script.sh /out/usr/bin/manage-startup-script.sh
 
+FROM ${ALPINE_BASE_IMAGE} as certs
+RUN apk --no-cache add ca-certificates
+
 FROM scratch
 COPY --from=builder /out /
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 CMD [ "/usr/bin/manage-startup-script.sh" ]

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -37,6 +37,11 @@ do_build="${FORCE:-false}"
 do_push="${PUSH:-false}"
 output="type=image,push=${do_push}"
 
+if [ "${do_push}" == "false" ]; then
+  export DOCKER_HUB_PUBLIC_ACCESS_ONLY=true
+  export QUAY_PUBLIC_ACCESS_ONLY=true
+fi
+
 do_export="${EXPORT:-false}"
 
 if [ "${with_root_context}" = "false" ] ; then


### PR DESCRIPTION
This PR contains two commits, one for adjusting the way we install `ca-certificates` in the `startup-script` image, and one to enable image builds in PRs from forks. Please see individual commits for details.

I opened a draft PR in `cilium/cilium` to test the changes to this image, see https://github.com/cilium/cilium/pull/33414. The helm-based checks are failing because I didn't update the generated documentation. All other checks that actually use the new `startup-script` image are passing.