### PR TITLE
startup-script: Adjust ca-certificates install to only copy certs

### DIFF
--- a/images/startup-script/Dockerfile
+++ b/images/startup-script/Dockerfile
@@ -9,12 +9,15 @@ RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 
 RUN apk add --initdb --no-cache --root /out \
     bash \
-    ca-certificates \
     util-linux \
     && true
 
 COPY manage-startup-script.sh /out/usr/bin/manage-startup-script.sh
 
+FROM ${ALPINE_BASE_IMAGE} as certs
+RUN apk --no-cache add ca-certificates
+
 FROM scratch
 COPY --from=builder /out /
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 CMD [ "/usr/bin/manage-startup-script.sh" ]


### PR DESCRIPTION
This commit adjusts the method in which `ca-certificates` is installed into the startup-script image. The `ca-certificates` package has a dependency on OpenSSL, which unnecessarily increases the attack surface of the image, since the image's only functionality is fully contained in `manage-startup-script.sh` and the script makes no network connections. The package could theoretically be removed, but as a precaution, the root certificates from the `ca-certificates` package are copied in to the image using the same method as is used in the Cilium Operator image.