### PR TITLE
Use latest directory commit timestamp as tag

### DIFF
--- a/images/network-perf/Dockerfile
+++ b/images/network-perf/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8:8.9-1136
+FROM registry.access.redhat.com/ubi8/ubi
 COPY appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs make --enablerepo=centos9 --allowerasing
 RUN dnf install -y --nodocs gcc --enablerepo=centos9 --allowerasing

--- a/scripts/make-image-tag.sh
+++ b/scripts/make-image-tag.sh
@@ -38,12 +38,7 @@ if [ "$#" -eq 1 ] ; then
     echo "${image_dir} is not a directory (path is relative to git root)"
     exit 1
   fi
-  git_ls_tree="$(git ls-tree --full-tree HEAD -- "${image_dir}")"
-  if [ -z "${git_ls_tree}" ] ; then
-    echo "${image_dir} exists, but it is not checked in git (path is relative to git root)"
-    exit 1
-  fi
-  image_tag="$(printf "%s" "${git_ls_tree}" | sed 's/^[0-7]\{6\} tree \([0-9a-f]\{40\}\).*/\1/')"
+  image_tag="$(git log -1 --pretty=format:"%ct" "${image_dir}")"
 else
   # if no arguments are given, attempt detecting if version tag is present,
   # otherwise use the a short commit hash

--- a/scripts/make-image-tag.sh
+++ b/scripts/make-image-tag.sh
@@ -38,7 +38,9 @@ if [ "$#" -eq 1 ] ; then
     echo "${image_dir} is not a directory (path is relative to git root)"
     exit 1
   fi
-  image_tag="$(git log -1 --pretty=format:"%ct" "${image_dir}")"
+  timestamp="$(git log -1 --pretty=format:"%ct" "${image_dir}")"
+  short_commit="$(git log -1 --pretty=format:"%h" "${image_dir}")"
+  image_tag="${timestamp}-${short_commit}"
 else
   # if no arguments are given, attempt detecting if version tag is present,
   # otherwise use the a short commit hash


### PR DESCRIPTION
This commit change the way of tagging image, from using git-lfs-tree sha256 to using directory's last commit timestamp. It will permit renovate to sort versions and update properly new images, where renovate wasn't able to do so before due to its inability to sort SHAs.
The git log command, when given a specific directory in parameter, retrieve the last commit were changes were made in said directory. This means that we can ensure different image versions same as used to be with git-tree.
Renovate can sort versions from left to right, using a timestamp as a tag value allows it to retrieve the latest version deployed with ease.