### PR TITLE
fix: get git history to make tagging mechanic work properly

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -20,6 +20,8 @@ jobs:
           echo "push=${PUSH}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
       - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Register binfmt from multi-platform builds
         with:

--- a/scripts/make-image-tag.sh
+++ b/scripts/make-image-tag.sh
@@ -32,7 +32,7 @@ root_dir="$(git rev-parse --show-toplevel)"
 cd "${root_dir}"
 
 if [ "$#" -eq 1 ] ; then
-  # if one argument was given, assume it's a directory and obtain a tree hash
+  # if one argument was given, assume it's a directory and retrieve its last commit to generate a tag
   image_dir="${1}"
   if ! [ -d "${image_dir}" ] ; then
     echo "${image_dir} is not a directory (path is relative to git root)"


### PR DESCRIPTION
actions/checkout by default retrieve only the last commit of the repository. If we want the tagging mechanic to work properly we need the full history so we can know the actual real last commit of the image directory when tagging