### PR TITLE
images: Add clang-format image

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -83,6 +83,16 @@ jobs:
           entrypoint: make
           args: llvm-image PUSH=${{ steps.vars.outputs.push }}
       - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
+        name: Run make clang-format-image
+        env:
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_CI }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD_IMAGE_TOOLS }}
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME_IMAGE_TOOLS }}
+        with:
+          entrypoint: make
+          args: clang-format-image PUSH=${{ steps.vars.outputs.push }}
+      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Run make startup-script-image
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PUSH ?= false
 EXPORT ?= false
 PLATFORMS ?= linux/amd64,linux/arm64
 
-all-images: lint maker-image tester-image compilers-image bpftool-image llvm-image network-perf-image ca-certificates-image startup-script-image checkpatch-image iptables-image
+all-images: lint maker-image tester-image compilers-image bpftool-image llvm-image clang-format-image network-perf-image ca-certificates-image startup-script-image checkpatch-image iptables-image
 
 
 lint:
@@ -30,6 +30,9 @@ bpftool-image: .buildx_builder
 
 llvm-image: .buildx_builder
 	PUSH=$(PUSH) EXPORT=$(EXPORT) TEST=true scripts/build-image.sh cilium-llvm images/llvm $(PLATFORMS) "$$(cat .buildx_builder)" $(REGISTRIES)
+
+clang-format-image: .buildx_builder
+	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh cilium-clang-format images/clang-format $(PLATFORMS) "$$(cat .buildx_builder)" $(REGISTRIES)
 
 ca-certificates-image: .buildx_builder
 	PUSH=$(PUSH) EXPORT=$(EXPORT) scripts/build-image.sh ca-certificates images/ca-certificates $(PLATFORMS) "$$(cat .buildx_builder)" $(REGISTRIES)

--- a/images/clang-format/Dockerfile
+++ b/images/clang-format/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2024 Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:5569a29cea6b3ad50aeb03102aaf3dc03841197c@sha256:b15dbedb7c49816c74a765e2f6ecdb9359763b8e4e4328d794f48b9cefae9804
+
+FROM --platform=linux/amd64 ${COMPILERS_IMAGE} as builder
+
+COPY checkout-llvm.sh /tmp/checkout-llvm.sh
+RUN /tmp/checkout-llvm.sh
+
+COPY build-llvm-native.sh /tmp/build-llvm-native.sh
+RUN /tmp/build-llvm-native.sh
+
+COPY build-llvm-cross-aarch64.sh /tmp/build-llvm-cross-aarch64.sh
+RUN /tmp/build-llvm-cross-aarch64.sh
+
+FROM scratch
+LABEL maintainer="maintainer@cilium.io"
+
+ARG TARGETPLATFORM
+COPY --from=builder /out/${TARGETPLATFORM}/bin /

--- a/images/clang-format/build-llvm-cross-aarch64.sh
+++ b/images/clang-format/build-llvm-cross-aarch64.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright 2017-2024 Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+set -o nounset
+
+triplet="aarch64-linux-gnu"
+
+mkdir -p /src/llvm/llvm/build-cross-aarch64
+
+cd /src/llvm/llvm/build-cross-aarch64
+
+CC="${triplet}-gcc" CXX="${triplet}-g++" \
+  cmake .. -G "Ninja" \
+    -DLLVM_TARGETS_TO_BUILD="BPF" \
+    -DLLVM_ENABLE_PROJECTS="clang" \
+    -DBUILD_SHARED_LIBS="OFF" \
+    -DLLVM_BUILD_STATIC="ON" \
+    -DCMAKE_CXX_FLAGS="-s -flto" \
+    -DCMAKE_BUILD_TYPE="Release" \
+    -DLLVM_BUILD_RUNTIME="OFF" \
+    -DLLVM_TABLEGEN="/src/llvm/llvm/build-native/bin/llvm-tblgen" \
+    -DCLANG_TABLEGEN="/src/llvm/llvm/build-native/bin/clang-tblgen" \
+    -DCMAKE_CROSSCOMPILING="True" \
+    -DCMAKE_INSTALL_PREFIX="/usr/local"
+
+ninja clang-format
+
+${triplet}-strip bin/clang-format
+
+mkdir -p /out/linux/arm64/bin
+cp bin/clang-format /out/linux/arm64/bin

--- a/images/clang-format/build-llvm-native.sh
+++ b/images/clang-format/build-llvm-native.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2017-2024 Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+set -o nounset
+
+mkdir -p /src/llvm/llvm/build-native
+
+cd /src/llvm/llvm/build-native
+
+cmake .. -G "Ninja" \
+  -DLLVM_TARGETS_TO_BUILD="BPF" \
+  -DLLVM_ENABLE_PROJECTS="clang" \
+  -DBUILD_SHARED_LIBS="OFF" \
+  -DLLVM_BUILD_STATIC="ON" \
+  -DCMAKE_CXX_FLAGS="-s -flto" \
+  -DCMAKE_BUILD_TYPE="Release" \
+  -DLLVM_BUILD_RUNTIME="OFF" \
+  -DCMAKE_INSTALL_PREFIX="/usr/local"
+
+# llvm-tblgen and clang-tblgen are needed to build the aarch64 version of clang-format
+ninja clang-format llvm-tblgen clang-tblgen
+
+strip bin/clang-format
+
+mkdir -p /out/linux/amd64/bin
+cp bin/clang-format /out/linux/amd64/bin

--- a/images/clang-format/checkout-llvm.sh
+++ b/images/clang-format/checkout-llvm.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Copyright 2017-2024 Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+set -o nounset
+
+rev="llvmorg-17.0.6"
+
+git config --global user.email "maintainer@cilium.io"
+git config --global user.name  "Cilium Maintainers"
+
+git clone --branch "${rev}" https://github.com/llvm/llvm-project.git /src/llvm


### PR DESCRIPTION
This PR part of an effort to start using clang-format in the Cilium project to format BPF code. This PR adds a minimal image for clang-format. It is a variation of the llvm image, main difference is that the resulting binaries are statically compiled. This allows them to run in a scratch image, drastically reducing the size of the docker image. It also allows for the possibility to copy the binary out of the docker image to be ran on local machines, for example to integrate into editors. Making it easy to ensure we use the same tool both locally and in CI to avoid formatting irregularities due to version mismatches.