### PR TITLE
maker: Update hadolint to 2.12.0

### DIFF
--- a/images/maker/Dockerfile
+++ b/images/maker/Dockerfile
@@ -1,23 +1,24 @@
-# syntax=docker/dockerfile:1.1-experimental@sha256:de85b2f3a3e8a2f7fe48e8e84a65f6fdd5cd5183afa6412fff9caa6871649c44
+# syntax=docker/dockerfile:1.2
 
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
 ARG DOCKER_IMAGE=docker.io/library/docker:28.2.2-dind@sha256:17aa5b215f2b70bc0e456a87bcdd93e8774f133c73452df69d89606abc555270
-ARG CRANE_IMAGE=gcr.io/go-containerregistry/crane:latest@sha256:5583664dfe9bb06b3e09ad612c91bd8378653d3ebec2e0b5e3d3d2c046b3b0a5
+ARG CRANE_IMAGE=gcr.io/go-containerregistry/crane:latest@sha256:13952b31a107e8bc4e4c170b0097edb708cd468486a28fc20bbf0d49f71c74e1
 ARG ALPINE_BASE_IMAGE=docker.io/library/alpine:3.22.0@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715
 ARG GOLANG_IMAGE=docker.io/library/golang:1.24.4@sha256:10c131810f80a4802c49cab0961bbe18a16f4bb2fb99ef16deaa23e4246fc817
 
-FROM ${DOCKER_IMAGE} as docker-dist
-FROM ${CRANE_IMAGE} as crane-dist
+FROM ${DOCKER_IMAGE} AS docker-dist
+FROM ${CRANE_IMAGE} AS crane-dist
 
-FROM ${GOLANG_IMAGE} as go-builder
+FROM ${GOLANG_IMAGE} AS go-builder
 
 # hadolint ignore=SC2215
 RUN --mount=type=bind,readwrite,target=/src --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
     /src/build-go-deps.sh
 
-FROM ${ALPINE_BASE_IMAGE} as builder
+FROM ${ALPINE_BASE_IMAGE} AS builder
+ARG TARGETARCH
 
 RUN apk add --no-cache \
     curl \
@@ -41,10 +42,14 @@ COPY --from=docker-dist /usr/local/bin /out/usr/local/bin
 COPY --from=crane-dist /ko-app/crane /out/usr/local/bin/crane
 COPY --from=go-builder /out /out
 
-ARG HADOLINT_VERSION=1.17.6
+ARG HADOLINT_VERSION=2.12.0
 
-RUN curl --fail --show-error --silent --location \
-      https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64 \
+RUN case "${TARGETARCH}" in \
+    'amd64') export ARCH='x86_64' ;; \
+    'arm64') export ARCH='arm64' ;; \
+    esac && \
+    curl --fail --show-error --silent --location \
+    https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-${ARCH} \
     --output /out/usr/local/bin/hadolint \
     && chmod +x /out/usr/local/bin/hadolint
 
@@ -54,7 +59,7 @@ RUN mkdir -p /out/etc/docker/cli-plugins \
 
 FROM scratch
 ENV DOCKER_CONFIG=/etc/docker
-# when `buldx create` is used, by defualt it stores configs of builder isntances in
+# when `buldx create` is used, by default it stores configs of builder isntances in
 # $BUILDX_CONFIG/buildx (or custom path set with $BUILDX_CONFIG);
 # default location works as long as home directory is persisted, across invocations,
 # but when invoked from inside a container the $DOCKER_CONFIG/buildx directory is not


### PR DESCRIPTION
This PR updates hadolint in the `maker` image from [1.17.6](https://github.com/hadolint/hadolint/releases/tag/v1.17.6) to [2.12.0](https://github.com/hadolint/hadolint/releases/tag/v2.12.0).

Additional changes:
* Install the right version of `hadolint` based on the arch instead of always installing the amd64 one.
* Fix [`FromAsCasing`](https://docs.docker.com/reference/build-checks/from-as-casing/) violations
* Use the multi-arch version of the crane image instead of its amd64 version, see this warning:
```
WARNING: InvalidBaseImagePlatform
Base image gcr.io/go-containerregistry/crane:latest@sha256:5583664dfe9bb06b3e09ad612c91bd8378653d3ebec2e0b5e3d3d2c046b3b0a5 was pulled with platform "linux/amd64", expected "linux/arm64" for current build
```
<details>
<summary>Details of the new sha</summary>

```sh
crane manifest gcr.io/go-containerregistry/crane:latest@sha256:13952b31a107e8bc4e4c170b0097edb708cd468486a28fc20bbf0d49f71c74e1 | jq

{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 1336,
      "digest": "sha256:0c48b992c3b04231c93f59eef3ed340fc4cce8ef5cbb34ef283c5692d0ef1b4d",
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 1336,
      "digest": "sha256:e15f1c848de7bcdf66dc66cd7a6ac1d5e757c922d85e5fe2e6f5147047dcf00a",
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    }
  ],
  "annotations": {
    "dev.chainguard.package.main": "",
    "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/",
    "org.opencontainers.image.base.digest": "sha256:1ff7590cbc50eaaa917c34b092de0720d307f67d6d795e4f749a0b80a2e95a2c",
    "org.opencontainers.image.base.name": "cgr.dev/chainguard/static:latest",
    "org.opencontainers.image.created": "2025-03-31T16:03:48Z",
    "org.opencontainers.image.source": "https://github.com/chainguard-images/images/tree/main/images/static",
    "org.opencontainers.image.url": "https://images.chainguard.dev/directory/image/static/overview",
    "org.opencontainers.image.vendor": "Chainguard"
  }
}
```


</details>

