### PR TITLE
tester: Only compile for the relevant platform

### DIFF
--- a/images/tester/Dockerfile
+++ b/images/tester/Dockerfile
@@ -1,35 +1,27 @@
-# syntax=docker/dockerfile:1.1-experimental@sha256:de85b2f3a3e8a2f7fe48e8e84a65f6fdd5cd5183afa6412fff9caa6871649c44
-
 # Copyright 2020 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
 ARG GOLANG_IMAGE=docker.io/library/golang:1.24.4@sha256:10c131810f80a4802c49cab0961bbe18a16f4bb2fb99ef16deaa23e4246fc817
 ARG ALPINE_BASE_IMAGE=docker.io/library/alpine:3.22.0@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715
 
-FROM --platform=linux/amd64 ${GOLANG_IMAGE} as go-builder
-
-COPY . /go/src/github.com/cilium/image-tools/images/tester
-RUN mkdir -p /out/linux/amd64/bin /out/linux/arm64/bin
+FROM ${GOLANG_IMAGE} AS go-builder
 
 WORKDIR /go/src/github.com/cilium/image-tools/images/tester/cst
 
 # hadolint ignore=SC2215
-RUN --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
-  env CGO_ENABLED=0 \
-    go build -tags netgo -ldflags '-s -w -extldflags "-static"' -o /out/linux/amd64/bin/cst
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/image-tools/images/tester \
+    --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/go/pkg \
+    mkdir -p /out/bin && \
+    CGO_ENABLED=0 go build -tags netgo -ldflags '-s -w -extldflags "-static"' -o /out/bin/cst
 
-# hadolint ignore=SC2215
-RUN --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
-  env CGO_ENABLED=0 GOARCH=arm64 \
-    go build -tags netgo -ldflags '-s -w -extldflags "-static"' -o /out/linux/arm64/bin/cst
+FROM ${ALPINE_BASE_IMAGE} AS test
 
-FROM ${ALPINE_BASE_IMAGE} as test
-ARG TARGETPLATFORM
-COPY --from=go-builder /out/${TARGETPLATFORM}/bin /test/bin
+COPY --from=go-builder /out/bin /test/bin
 COPY test /test
-RUN /test/bin/cst
+RUN /test/bin/cst -C /test
 
 FROM scratch
 LABEL maintainer="maintainer@cilium.io"
-ARG TARGETPLATFORM
-COPY --from=go-builder /out/${TARGETPLATFORM}/bin /test/bin
+
+COPY --from=go-builder /out/bin /test/bin


### PR DESCRIPTION
Similar to #339 and #343

Summary of changes:
* Remove `syntax=docker/dockerfile` line: see https://github.com/cilium/image-tools/pull/339#discussion_r2177483937 for reasonning
* Only build the `cst` binary for the relevant `TARGETARCH` instead of building it twice for both `linux/amd64` and `linux/arm64` to later only keep the right binary
* Replace a `COPY` with a bind mount on the compile `RUN` instruction 
  * (`COPY . /go/src/github.com/cilium/image-tools/images/tester` replaced with `RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/image-tools/images/tester`)
  * this is more consistent with [established patterns](https://github.com/search?q=repo%3Acilium%2Fcilium+path%3A%2F%5Eimages%5C%2F%2F+bind&type=code) in `cilium/cilium`