### PR TITLE
network-perf: Optimize image build and size

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -8,6 +8,5 @@ ignored:
 # in most cases, packages are installed via scripts and those don't get checked
 # (albeit, ubuntu repos tend to keep old versions around)
 - DL3008
-# this one just needs to be set, but since `FROM ${BASE_IMAGE}` cannot be parse,
-# there isn't a way to leverage this feature anyway
-allowedRegistries: []
+# similar as the two above, disable package version pinning for dnf
+- DL3041

--- a/images/network-perf/Dockerfile
+++ b/images/network-perf/Dockerfile
@@ -1,13 +1,35 @@
-FROM registry.access.redhat.com/ubi8/ubi@sha256:0c1757c4526cfd7fdfedc54fadf4940e7f453201de65c0fefd454f3dde117273
+ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi@sha256:0c1757c4526cfd7fdfedc54fadf4940e7f453201de65c0fefd454f3dde117273
+
+FROM ${BASE_IMAGE} AS builder
+
+# We can ignore this warning here because we run `dnf clean all` later and then squash all layers in the final image
+# hadolint ignore=DL3040
 RUN dnf install -y --nodocs gcc make
-RUN curl -L -o iperf.tar.gz https://github.com/esnet/iperf/archive/refs/tags/3.19.tar.gz
-RUN curl -L -o netperf.tar.gz https://github.com/HewlettPackard/netperf/archive/80bf19d563eebd1eca23f4092f96819296020fa5.tar.gz
-RUN mkdir /iperf && tar xzf iperf.tar.gz --strip-components=1 -C /iperf
-RUN mkdir /netperf && tar xzf netperf.tar.gz --strip-components=1 -C /netperf
+
+# Install and configure iperf
+ARG IPERF_VERSION=3.19
 WORKDIR /iperf
-RUN ./configure && make && make install
+RUN curl -L -o iperf.tar.gz https://github.com/esnet/iperf/archive/refs/tags/${IPERF_VERSION}.tar.gz && \
+    tar xzf iperf.tar.gz --strip-components=1 -C /iperf && \
+    ./configure && \
+    make && \
+    make install && \
+    rm -rf /iperf
+
+# Install and configure netperf
+ARG NETPERF_VERSION=80bf19d563eebd1eca23f4092f96819296020fa5
 WORKDIR /netperf
-RUN ./configure && make && make install
-RUN rm -rf /iperf /iperf.tar.gz
-RUN rm -rf /netperf /netperf.tar.gz
-RUN dnf remove -y gcc make
+RUN curl -L -o netperf.tar.gz https://github.com/HewlettPackard/netperf/archive/${NETPERF_VERSION}.tar.gz && \
+    tar xzf netperf.tar.gz --strip-components=1 -C /netperf && \
+    ./configure && \
+    make && \
+    make install && \
+    rm -rf /netperf
+
+# Remove build dependencies
+RUN dnf remove -y gcc make && \
+    dnf clean all
+
+FROM scratch
+LABEL maintainer="maintainer@cilium.io"
+COPY --from=builder / /


### PR DESCRIPTION
This PR performs a couple of optimizations to the `network-perf` image. Currently that image presents multiple hadolint issues:
```
./images/network-perf/Dockerfile:2 DL3040 warning: `dnf clean all` missing after dnf command.
./images/network-perf/Dockerfile:2 DL3041 warning: Specify version with `dnf install -y <package>-<version>`.
./images/network-perf/Dockerfile:3 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
./images/network-perf/Dockerfile:4 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
./images/network-perf/Dockerfile:12 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
./images/network-perf/Dockerfile:13 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
```
As a result of its multiple separate consecutive `RUN` statements, the image ends up with many layers that are making it inefficient (files get created and later deleted in a different layer, causing them to still end up in the final image).

Summary of the changes:
* Consolidate `RUN` statements: one for `iperf` and one for `netperf`
* Parameterize the image: create build args for `BASE_IMAGE`, `IPERF_VERSION` and `NETPERF_VERSION` which will help things like #349
* Add `DL3041` to the list of hadolint ignored rules
* Add `dnf clean all` to the cleanup step
* Squash all layers to reduce the size of the final image

Current image:
<img width="485" alt="image" src="https://github.com/user-attachments/assets/e441365e-5934-487f-9ef2-ff9f1dab92c1" />
Updated image:
<img width="485" alt="image" src="https://github.com/user-attachments/assets/233c7340-0abe-4c01-bd70-3a5bd58984d1" />
