### PR TITLE
ci: Remove duplicate `make lint` runs

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -44,11 +44,6 @@ jobs:
           entrypoint: docker
           args: run --privileged linuxkit/binfmt:a17941b47f5cb262638cfb49ffc59ac5ac2bf334
       - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
-        name: Run make lint
-        with:
-          entrypoint: sh
-          args: -c "git config --global --add safe.directory /github/workspace && make lint"
-      - uses: docker://quay.io/cilium/image-maker:e55375ca5ccaea76dc15a0666d4f57ccd9ab89de
         name: Run make ${{ matrix.image }}-image
         env:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
@@ -56,5 +51,5 @@ jobs:
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD_IMAGE_TOOLS }}
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME_IMAGE_TOOLS }}
         with:
-          entrypoint: make
-          args: "${{ matrix.image }}-image PUSH=${{ steps.vars.outputs.push }}"
+          entrypoint: sh
+          args: -c "git config --global --add safe.directory /github/workspace && make ${{ matrix.image }}-image PUSH=${{ steps.vars.outputs.push }}"


### PR DESCRIPTION
`make lint` already runs as part of the separate [`Run static checks`](https://github.com/cilium/image-tools/blob/master/.github/workflows/pr-checks.yaml) workflow and does a repo-wide check of all Dockerfiles.

The step that's being removed here causes `make lint` to also run for every single image build job, which is unnecessary.