### PR TITLE
renovate: Group base images updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -90,20 +90,18 @@
         "master",
       ]
     },
+    // Group base images updates
     {
-      // Images that directly use docker.io/library/golang for building.
-      "groupName": "golang-images",
-      "matchFiles": [
-        "Dockerfile",
-      ]
-    },
-    {
+      "matchDatasources": ["docker"],
       "matchPackageNames": [
-        "docker.io/library/alpine"
+        "docker.io/library/alpine",
+        "docker.io/library/docker",
+        "docker.io/library/golang",
+        "docker.io/library/ubuntu",
+        "gcr.io/go-containerregistry/crane",
+        "registry.access.redhat.com/ubi8/ubi"
       ],
-      "matchPaths": [
-        "Dockerfile"
-      ],
+      "schedule": ["on the first day of the month"]
     },
   ],
   "regexManagers": [


### PR DESCRIPTION
Currently a couple of docker images use `latest` or an equivalently mutable tag that gets republished almost daily, this leads to renovate constantly trying to update the digest for those images. In practice it means that as soon as we merge a renovate PR for a given image, renovate creates a new one for that same image.

With this PR we introduce two changes to the renovate config concerning docker image updates:
* Group them all together, meaning there will be a single PR for all base images updates instead of one per base image
* Only do these updates monthly (I'm open to any other suggested frequency, the main goal is to avoid having a new PR created as soon as one is merged, although #335 should help with the PR toil)