### PR TITLE
tester: Remove deprecated `ioutil` usage

### DIFF
--- a/images/tester/cst/main.go
+++ b/images/tester/cst/main.go
@@ -6,12 +6,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 
 	"github.com/GoogleContainerTools/container-structure-test/cmd/container-structure-test/app/cmd/test"
-
 	"github.com/GoogleContainerTools/container-structure-test/pkg/color"
 	"github.com/GoogleContainerTools/container-structure-test/pkg/drivers"
 	"github.com/GoogleContainerTools/container-structure-test/pkg/types/unversioned"
@@ -90,7 +88,7 @@ func main() {
 
 func fakeMetadata() (string, error) {
 	content := []byte(`{ "config": {} }`)
-	file, err := ioutil.TempFile("", "metadata")
+	file, err := os.CreateTemp("", "metadata")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Replace [`ioutil.TempFile`](https://pkg.go.dev/io/ioutil#TempFile) with [`os.CreateTemp`](https://pkg.go.dev/os#CreateTemp).