### PR TITLE
update github runners to oci gh arc runners

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -18,7 +18,7 @@ jobs:
 
   build-and-push:
     name: ${{ github.event_name == 'push' && 'Build and push' || 'Build' }} ${{ matrix.image }} image
-    runs-on: ubuntu-latest-32-cores-128gb
+    runs-on: oracle-vm-32cpu-128gb-x86-64
     needs: generate-images-matrix
     strategy:
       fail-fast: false


### PR DESCRIPTION
CNCF has hosted ephemeral GitHub runners on Oracle that we want projects to use instead of the GitHub-hosted ones, which now incur a cost to use.

Please direct any questions to me, @jeefy, @krook, and @RobertKielty. You can also join `#cncf-ci-infra` channel on CNCF Slack.
