### PR TITLE
llvm: Build optimized and static binaries

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -24,6 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         image: ${{ fromJSON(needs.generate-images-matrix.outputs.matrix).images }}
+    timeout-minutes: 720
     steps:
       - name: Set up job variables
         id: vars

--- a/images/llvm/Dockerfile
+++ b/images/llvm/Dockerfile
@@ -4,7 +4,9 @@
 ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:1732033829-330cbaf@sha256:5c54f614fb8ee7939492aa4b7d74b37922d98199f5993f6d957a1637ce30eb9e
 ARG UBUNTU_IMAGE=docker.io/library/ubuntu:24.04@sha256:278628f08d4979fb9af9ead44277dbc9c92c2465922310916ad0c46ec9999295
 ARG TESTER_IMAGE=quay.io/cilium/image-tester:dd09c8d3ef349a909fbcdc99279516baef153f22@sha256:c056d064cb47c97acd607343db5457e1d49d9338d6d8a87e93e23cc93f052c73
+ARG BASE_IMAGE=scratch
 
+FROM ${TESTER_IMAGE} AS tester
 FROM ${COMPILERS_IMAGE} AS builder
 
 COPY checkout-llvm.sh /tmp/checkout-llvm.sh
@@ -13,15 +15,12 @@ RUN /tmp/checkout-llvm.sh
 COPY build-llvm.sh /tmp/build-llvm.sh
 RUN /tmp/build-llvm.sh
 
-FROM ${UBUNTU_IMAGE} AS rootfs
-
+FROM ${UBUNTU_IMAGE} AS test
 COPY --from=builder /out/bin /usr/local/bin
-
-FROM ${TESTER_IMAGE} AS test
-COPY --from=rootfs / /
 COPY test /test
+COPY --from=tester /test/bin /test/bin
 RUN /test/bin/cst -C /test
 
-FROM scratch
+FROM ${BASE_IMAGE} AS release
 LABEL maintainer="maintainer@cilium.io"
-COPY --from=rootfs / /
+COPY --from=builder /out/bin /usr/local/bin

--- a/images/llvm/build-llvm.sh
+++ b/images/llvm/build-llvm.sh
@@ -15,6 +15,8 @@ cmake .. -G "Ninja" \
     -DLLVM_TARGETS_TO_BUILD="BPF" \
     -DLLVM_ENABLE_PROJECTS="clang" \
     -DBUILD_SHARED_LIBS="OFF" \
+    -DLLVM_BUILD_STATIC="ON" \
+    -DCMAKE_CXX_FLAGS="-s -flto" \
     -DCMAKE_BUILD_TYPE="Release" \
     -DLLVM_BUILD_RUNTIME="OFF" \
     -DCMAKE_INSTALL_PREFIX="/usr/local"

--- a/images/llvm/test/spec.yaml
+++ b/images/llvm/test/spec.yaml
@@ -1,32 +1,91 @@
 schemaVersion: "2.0.0"
 
 commandTests:
-- name: "llc command is in path"
-  command: "which"
-  args: ["llc"]
-  expectedOutput: ["/usr/local/bin/llc"]
-- name: "llc --version"
-  command: "llc"
-  args: ["--version"]
-  expectedOutput:
-  - 'LLVM\ \(http://llvm\.org/\):'
-  - 'LLVM\ version\ 19\.1\.7'
-  - 'Optimized\ build\.'
-  - 'Registered\ Targets:'
-  - '(bpf|bpfeb|bpfel)[\ ]+-\ BPF\ \((host|big|little)\ endian\)'
-  excludedOutput:
-  - '(aarch64|arm|misp|ppc|risc|sparc|thumb|wasm|x86).*\[\ ]+-\ .*'
-- name: "clang command is in path"
-  command: "which"
-  args: ["clang"]
-  expectedOutput: ["/usr/local/bin/clang"]
-- name: "clang --version"
-  command: "clang"
-  args: ["--version"]
-  expectedOutput:
-  - 'clang\ version\ 19\.1\.7\ \(https://github.com/llvm/llvm-project.git\ .*\)'
-  - 'InstalledDir:\ /usr/local/bin'
+  # clang tests
+  - name: "clang command is in path"
+    command: "which"
+    args: ["clang"]
+    expectedOutput: ["/usr/local/bin/clang"]
 
-- name: "clang can compile a simple BPF program"
-  command: "clang"
-  args: [ "-O2", "-target", "bpf", "-c", "test.c", "-o", "/tmp/test.o" ]
+  - name: "clang is statically linked"
+    command: "ldd"
+    args: ["/usr/local/bin/clang"]
+    expectedError: ["not a dynamic executable"]
+    exitCode: 1
+
+  - name: "clang --version"
+    command: "clang"
+    args: ["--version"]
+    expectedOutput:
+      - 'clang\ version\ 19\.1\.7\ \(https://github.com/llvm/llvm-project.git\ .*\)'
+      - 'InstalledDir:\ /usr/local/bin'
+
+  - name: "clang can compile a simple BPF program"
+    command: "clang"
+    args: [ "-O2", "-target", "bpf", "-c", "test.c", "-o", "/tmp/test.o" ]
+
+  # llc tests
+  - name: "llc command is in path"
+    command: "which"
+    args: ["llc"]
+    expectedOutput: ["/usr/local/bin/llc"]
+
+  - name: "llc is statically linked"
+    command: "ldd"
+    args: ["/usr/local/bin/llc"]
+    expectedError: ["not a dynamic executable"]
+    exitCode: 1
+
+  - name: "llc --version"
+    command: "llc"
+    args: ["--version"]
+    expectedOutput:
+      - 'LLVM\ \(http://llvm\.org/\):'
+      - 'LLVM\ version\ 19\.1\.7'
+      - 'Optimized\ build\.'
+      - 'Registered\ Targets:'
+      - '(bpf|bpfeb|bpfel)[\ ]+-\ BPF\ \((host|big|little)\ endian\)'
+    excludedOutput:
+      - '(aarch64|arm|misp|ppc|risc|sparc|thumb|wasm|x86).*\[\ ]+-\ .*'
+
+  # llvm-objcopy tests
+  - name: "llvm-objcopy command is in path"
+    command: "which"
+    args: ["llvm-objcopy"]
+    expectedOutput: ["/usr/local/bin/llvm-objcopy"]
+
+  - name: "llvm-objcopy is statically linked"
+    command: "ldd"
+    args: ["/usr/local/bin/llvm-objcopy"]
+    expectedError: ["not a dynamic executable"]
+    exitCode: 1
+
+  - name: "llvm-objcopy --version"
+    command: "llvm-objcopy"
+    args: ["--version"]
+    expectedOutput:
+      - 'llvm-objcopy,\ compatible\ with\ GNU\ objcopy'
+      - 'LLVM\ \(http://llvm\.org/\):'
+      - 'LLVM\ version\ 19\.1\.7'
+      - 'Optimized\ build\.'
+
+  # llvm-strip tests
+  - name: "llvm-strip command is in path"
+    command: "which"
+    args: ["llvm-strip"]
+    expectedOutput: ["/usr/local/bin/llvm-strip"]
+
+  - name: "llvm-strip is statically linked"
+    command: "ldd"
+    args: ["/usr/local/bin/llvm-strip"]
+    expectedError: ["not a dynamic executable"]
+    exitCode: 1
+
+  - name: "llvm-strip --version"
+    command: "llvm-strip"
+    args: ["--version"]
+    expectedOutput:
+      - 'llvm-strip,\ compatible\ with\ GNU\ strip'
+      - 'LLVM\ \(http://llvm\.org/\):'
+      - 'LLVM\ version\ 19\.1\.7'
+      - 'Optimized\ build\.'


### PR DESCRIPTION
This PR takes inspiration from #306 to update the build process of the binaries in the `llvm` image:
> main difference is that the resulting binaries are statically compiled. This allows them to run in a scratch image, drastically reducing the size of the docker image

The core differences are:
* `-DLLVM_BUILD_STATIC="ON"` -> ensures the produced binaries are statically linked
* `-DCMAKE_CXX_FLAGS="-s -flto"` -> ensures the produced binaries are stripped and use link time optimization

Since the binaries are now all static, they can be delivered in a `FROM scratch` image instead of the current `ubuntu` based image. This results in an overall smaller image.

Updating the build flags actually also leads to ~20% smaller binaries, contributing to a smaller final image:
* Current image:

| `linux/arm64` | `linux/amd64` |
|----------|----------|
| `/usr/local/bin`: 161 Mb  <br> <img width="332" height="95" alt="image" src="https://github.com/user-attachments/assets/ca5b98d3-809c-4769-a609-5aff7ad53dcd" /> | `/usr/local/bin`: 175 Mb  <br><img width="332" height="95" alt="image" src="https://github.com/user-attachments/assets/6b0f6f79-c153-4c90-95e7-dce15f987513" /> |


* With static build:

| `linux/arm64` | `linux/amd64` |
|----------|----------|
| `/usr/local/bin`: 151 Mb  <br> <img width="332" height="95" alt="image" src="https://github.com/user-attachments/assets/7922b391-76b4-4697-8d0e-bd0fd864a76f" /> | `/usr/local/bin`: 168 Mb  <br><img width="332" height="95" alt="image" src="https://github.com/user-attachments/assets/e93291c6-4f51-42c9-ae22-6147fea436b5" /> |




* With static build and `flto`:

| `linux/arm64` | `linux/amd64` |
|----------|----------|
| `/usr/local/bin`: 126 Mb  <br> <img width="332" height="95" alt="image" src="https://github.com/user-attachments/assets/0bfe759e-6397-458f-887f-af494f061909" /> | `/usr/local/bin`: 137 Mb  <br> <img width="332" height="95" alt="image" src="https://github.com/user-attachments/assets/6553d64b-4dda-461c-b6b7-55e388a8daea" /> |





Combined with the switch from an `ubuntu` base to a `scratch` one, this reduces the `llvm` image size by about 50% (from 262Mb to 126Mb for `linux/arm64`).

Additional changes:
* I updated and extended the CST tests so that every binary in the image has at least:
  * a `which` test
  * an `ldd` test
  * a `<bin> --version` smoke test
* I had to bump the timeout for the image build job as the LLVM image build was taking just a little over the default timeout, especially when using the optimizing flag `-flto` and building a crossed-compiled `arm64` image from the `amd64` CI runner.
