### PR TITLE
Add renovate custom regex manager to tool updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -124,5 +124,14 @@
         "// renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+go (?<currentValue>.*)"
       ]
     },
+    {
+      "fileMatch": [
+        "images/**/Dockerfile"
+      ],
+      "matchStrings": [
+        '# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+ARG .*_VERSION="(?<currentValue>.*)"'
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+ARG .*_VERSION=(?<currentValue>.*)"
+      ]
+    },
   ]
 }


### PR DESCRIPTION
See #349

This PR configures renovate to recognize custom `# renovate:` comments in
Dockerfiles. One such comment is already present [here](https://github.com/cilium/image-tools/blob/49d7b282e76f941d6bf5abc4f125d14a1a7b2211/images/bpftool/Dockerfile#L12) (since https://github.com/cilium/image-tools/pull/366) and will allow to validate that this renovate config works as expected. If that is the case, we will be able to add more renovate comments to manage the versioning of other tools as listed in https://github.com/cilium/image-tools/issues/349.

This is largely inspired from the renovate config in cilium/cilium.