### PR TITLE
checkpatch: re-enable verification of PRs against all branches and let it work on private repos

### DIFF
--- a/images/checkpatch/checkpatch.sh
+++ b/images/checkpatch/checkpatch.sh
@@ -221,7 +221,7 @@ if [ -n "$GITHUB_REF" ]; then
     check_cmd curl
     pr=${GITHUB_REF#"refs/pull/"}
     prnum=${pr%"/merge"}
-    commits_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${prnum}/commits"
+    commits_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${prnum}/commits?per_page=100"
     list_commits=$(curl --fail --show-error --silent \
         -H "Accept: application/vnd.github+json" \
         -H "Authorization: Bearer ${GITHUB_TOKEN}" \


### PR DESCRIPTION
Make the checkpatch wrapper script exit with a non-zero error code if any command fails, or it attempts to access undefined variables, to prevent silent failures.

---

1392d2f42d82 ("checkpatch: skip verification on backport PRs") disabled running checkpatch against stable branches, as at that time the check turned out being too noisy on backport PRs, which is also not the right place to fix style errors.

However, it's been a long time since then, and the expectation is that both the main and stable branches are in a much better shape now, which should strongly reduce the possibility of hitting failures during backports. Hence, I'd argue it is time to enable checkpatch for all branches again, which has the nice side-effects of reducing the likelihood of silent breakages if the default branch does not match one of the previously hardcoded ones, as well as getting early signals when working e.g., against feature branches, rather than having to wait for feedback until actually targeting the main branch.

---

 Explicitly configure the accepted format and API version, to prevent surprises in case of any changes. Additionally, let curl fail with a non-zero exit code in case of errors.

---

Allow specifying the GitHub secret used to retrieve the list of commits for the target PR, as the request would otherwise fail in case of private repositories. 

---

By default, the commits API returns 30 results per-page. Let's increase this to the maximum possible, that is 100, to reduce the likelihood of actually hitting this limit, without having to implement proper handling of pagination. While I've seen PRs with 30ish commits in the past, I don't think I've ever seen one with 100 commits, so I think we should be fine from that point of view. I would expect reviewers to complain anyhow with that many commits.