### PR TITLE
checkpatch: prevent unbound variable error

### DIFF
--- a/images/checkpatch/checkpatch.sh
+++ b/images/checkpatch/checkpatch.sh
@@ -215,7 +215,7 @@ fi
 
 check_cmd git ifne jq
 
-if [ -n "$GITHUB_REF" ]; then
+if [ -n "${GITHUB_REF-}" ]; then
     # Running as GitHub action
     # We'll run checkpatch on each commit from the PR
     check_cmd curl
@@ -256,11 +256,11 @@ ret=0
 for ((i=0; i<nb_commits; i++)); do
     sha=$(echo "$list_commits" | jq -r ".[$i].sha")
     subject=$(echo "$list_commits" | jq -r ".[$i].subject")
-    check_commit "$((i+1))" "$nb_commits" "$sha" "$subject" "$GITHUB_REF"
+    check_commit "$((i+1))" "$nb_commits" "$sha" "$subject" "${GITHUB_REF-}"
 done
 
 # If not a GitHub action and repo is dirty, run on diff from HEAD
-if [ -z "$GITHUB_REF" ] && ! (git diff --exit-code && git diff --cached --exit-code) >/dev/null; then
+if [ -z "${GITHUB_REF-}" ] && ! (git diff --exit-code && git diff --cached --exit-code) >/dev/null; then
     echo "========================================================="
     echo -e "${HL_START}Running on changes from local HEAD$HL_END"
     echo "========================================================="


### PR DESCRIPTION
The blamed commit set the option to make the script fail if it tries to access any unbound variables, to catch possible errors. However, the script now fails when invoked directly, due to:

> ./checkpatch.sh: line 218: GITHUB_REF: unbound variable

While this is not a problem in practice, given that the Cilium's Makefile always sets the GITHUB_REF variable (possibly empty), let's guard the variable accesses, to be a bit more user-friendly.

Fixes: 5d11067d6e07 ("checkpatch: make script exit if command exits with error")