### PR TITLE
Fix docker credentials setup in CI

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -39,15 +39,19 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392  # v3.6.0
+
+      - name: Login to quay.io
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME_IMAGE_TOOLS }}
+          password: ${{ secrets.QUAY_PASSWORD_IMAGE_TOOLS }}
+
       - uses: docker://quay.io/cilium/image-maker:1755027480-74de989@sha256:be90a4b1ccb7553e54f8eb8224a82a5f886cdbd6057dafc9d36205615f46d696
         name: Run make ${{ matrix.image }}-image
-        env:
-          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD_CI }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME_CI }}
-          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD_IMAGE_TOOLS }}
-          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME_IMAGE_TOOLS }}
         with:
           entrypoint: sh
-          args: -c "git config --global --add safe.directory /github/workspace && make ${{ matrix.image }}-image PUSH=${{ steps.vars.outputs.push }}"
+          args: -c "git config --global --add safe.directory /github/workspace && rm /etc/docker/config.json && make ${{ matrix.image }}-image PUSH=${{ steps.vars.outputs.push }}"


### PR DESCRIPTION
This PR updates the CI config to prevent the issue described in #385 from happening.

The latest version of the `maker` image, used in CI to build images, has a broken docker credentials setup. This PR does the following:
* Use the standard `docker/login-action` action to handle login in and out of quay.io in CI
* Drop dockerhub credentials as we haven't been publishing images to dockerhub for many years now
* Remove the custom experimental docker credentials config that's causing the issue https://github.com/cilium/image-tools/blob/c5bf38b0035bcefd23af7c1c53a52c8ebe815f89/images/maker/Dockerfile#L57
  * Note: a followup PR will update the `maker` image so we don't need to remove this file like that on every CI job.