### PR TITLE
renovate: Replace `fileMatch` with `managerFilePatterns`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -106,7 +106,7 @@
   ],
   "regexManagers": [
     {
-      "fileMatch": [
+      "managerFilePatterns": [
         "^\\.github/workflows/[^/]+\\.yaml$"
       ],
       // This regex manages version strings in GitHub actions workflow files,
@@ -117,7 +117,7 @@
       ]
     },
     {
-      "fileMatch": [
+      "managerFilePatterns": [
         "^go\\.mod$"
       ],
       "matchStrings": [
@@ -125,7 +125,7 @@
       ]
     },
     {
-      "fileMatch": [
+      "managerFilePatterns": [
         "images/**/Dockerfile"
       ],
       "matchStrings": [


### PR DESCRIPTION
See [renovate documentation](https://docs.renovatebot.com/configuration-options/#managerfilepatterns):

> Formerly known as fileMatch, which supported regex-only.
>
> managerFilePatterns supports both regex and glob patterns. Any existing config containing fileMatch patterns will be automatically migrated.

PR #369 introduced a custom manager with a `fileMatch` attribute containing a glob pattern, when `fileMatch` only supports regex, causing #393.

This PR replaces all `fileMatch` in custom managers to `managerFilePatterns`which supports both glob patterns and regexp.

Fixes #393