### PR TITLE
llvm: Enable renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -111,6 +111,16 @@
         'on the first day of the month',
       ],
     },
+    // Handle LLVM tags with llvmorg- prefix
+    {
+      matchDatasources: [
+        'github-releases',
+      ],
+      matchPackageNames: [
+        'llvm/llvm-project',
+      ],
+      extractVersion: '^llvmorg-(?<version>.+)$',
+    },
   ],
   customManagers: [
     {
@@ -149,7 +159,7 @@
         'images/*/test/spec.yaml',
       ],
       matchStrings: [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+- 'bpftool (?<currentValue>.*)'",
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+- '(bpftool|clang version|LLVM version) (?<currentValue>.*)'",
       ],
     },
   ],

--- a/images/llvm/Dockerfile
+++ b/images/llvm/Dockerfile
@@ -9,8 +9,9 @@ ARG BASE_IMAGE=scratch
 FROM ${TESTER_IMAGE} AS tester
 FROM ${COMPILERS_IMAGE} AS builder
 
-ARG LLVM_VERSION="llvmorg-19.1.7"
-ADD https://github.com/llvm/llvm-project/archive/${LLVM_VERSION}.tar.gz /tmp/llvm.tar.gz
+# renovate: datasource=github-releases depName=llvm/llvm-project
+ARG LLVM_VERSION="19.1.7"
+ADD https://github.com/llvm/llvm-project/archive/llvmorg-${LLVM_VERSION}.tar.gz /tmp/llvm.tar.gz
 WORKDIR /src/llvm
 RUN tar -xf /tmp/llvm.tar.gz --strip-components=1 --directory /src/llvm
 

--- a/images/llvm/Dockerfile
+++ b/images/llvm/Dockerfile
@@ -9,8 +9,9 @@ ARG BASE_IMAGE=scratch
 FROM ${TESTER_IMAGE} AS tester
 FROM ${COMPILERS_IMAGE} AS builder
 
-ARG LLVM_VERSION="llvmorg-21.1.8"
-ADD https://github.com/llvm/llvm-project/archive/${LLVM_VERSION}.tar.gz /tmp/llvm.tar.gz
+# renovate: datasource=github-releases depName=llvm/llvm-project
+ARG LLVM_VERSION="21.1.8"
+ADD https://github.com/llvm/llvm-project/archive/llvmorg-${LLVM_VERSION}.tar.gz /tmp/llvm.tar.gz
 WORKDIR /src/llvm
 RUN tar -xf /tmp/llvm.tar.gz --strip-components=1 --directory /src/llvm
 

--- a/images/llvm/test/spec.yaml
+++ b/images/llvm/test/spec.yaml
@@ -17,7 +17,8 @@ commandTests:
     command: "clang"
     args: ["--version"]
     expectedOutput:
-      - 'clang\ version\ 19\.1\.7'
+      # renovate: datasource=github-releases depName=llvm/llvm-project
+      - 'clang version 19.1.7'
       - 'InstalledDir:\ /usr/local/bin'
 
   - name: "clang can compile a simple BPF program"
@@ -41,7 +42,8 @@ commandTests:
     args: ["--version"]
     expectedOutput:
       - 'LLVM\ \(http://llvm\.org/\):'
-      - 'LLVM\ version\ 19\.1\.7'
+      # renovate: datasource=github-releases depName=llvm/llvm-project
+      - 'LLVM version 19.1.7'
       - 'Optimized\ build\.'
       - 'Registered\ Targets:'
       - '(bpf|bpfeb|bpfel)[\ ]+-\ BPF\ \((host|big|little)\ endian\)'
@@ -66,7 +68,8 @@ commandTests:
     expectedOutput:
       - 'llvm-objcopy,\ compatible\ with\ GNU\ objcopy'
       - 'LLVM\ \(http://llvm\.org/\):'
-      - 'LLVM\ version\ 19\.1\.7'
+      # renovate: datasource=github-releases depName=llvm/llvm-project
+      - 'LLVM version 19.1.7'
       - 'Optimized\ build\.'
 
   # llvm-strip tests
@@ -87,5 +90,6 @@ commandTests:
     expectedOutput:
       - 'llvm-strip,\ compatible\ with\ GNU\ strip'
       - 'LLVM\ \(http://llvm\.org/\):'
-      - 'LLVM\ version\ 19\.1\.7'
+      # renovate: datasource=github-releases depName=llvm/llvm-project
+      - 'LLVM version 19.1.7'
       - 'Optimized\ build\.'

--- a/images/llvm/test/spec.yaml
+++ b/images/llvm/test/spec.yaml
@@ -17,7 +17,8 @@ commandTests:
     command: "clang"
     args: ["--version"]
     expectedOutput:
-      - 'clang\ version\ 21\.1\.8'
+      # renovate: datasource=github-releases depName=llvm/llvm-project
+      - 'clang version 21.1.8'
       - 'InstalledDir:\ /usr/local/bin'
 
   - name: "clang can compile a simple BPF program"
@@ -41,7 +42,8 @@ commandTests:
     args: ["--version"]
     expectedOutput:
       - 'LLVM\ \(http://llvm\.org/\):'
-      - 'LLVM\ version\ 21\.1\.8'
+      # renovate: datasource=github-releases depName=llvm/llvm-project
+      - 'LLVM version 21.1.8'
       - 'Optimized\ build\.'
       - 'Registered\ Targets:'
       - '(bpf|bpfeb|bpfel)[\ ]+-\ BPF\ \((host|big|little)\ endian\)'
@@ -66,7 +68,8 @@ commandTests:
     expectedOutput:
       - 'llvm-objcopy,\ compatible\ with\ GNU\ objcopy'
       - 'LLVM\ \(http://llvm\.org/\):'
-      - 'LLVM\ version\ 21\.1\.8'
+      # renovate: datasource=github-releases depName=llvm/llvm-project
+      - 'LLVM version 21.1.8'
       - 'Optimized\ build\.'
 
   # llvm-strip tests
@@ -87,5 +90,6 @@ commandTests:
     expectedOutput:
       - 'llvm-strip,\ compatible\ with\ GNU\ strip'
       - 'LLVM\ \(http://llvm\.org/\):'
-      - 'LLVM\ version\ 21\.1\.8'
+      # renovate: datasource=github-releases depName=llvm/llvm-project
+      - 'LLVM version 21.1.8'
       - 'Optimized\ build\.'


### PR DESCRIPTION
This PR enables renovate to update LLVM in the `cilium-llvm` image, similarly to what was done in #428 for bpftools.

<img width="460" height="276" alt="image" src="https://github.com/user-attachments/assets/3f4f3da4-f75f-47e8-970e-e861f83ff7a6" />


This means we will no longer need to manually do PRs such as #540. Now anytime there's a new LLVM release, we'll get a corresponding cilium-llvm image.

This is also completely safe as https://github.com/cilium/cilium/pull/48625 disabled auto-update of this image in cilium/cilium, so bumping the LLVM version in cilium/cilium remains a conscious manual action. The difference is that now such updates won't require first doing a PR here in image-tools as we'll already have pre-built images for every LLMV release on hand.