### PR TITLE
bpftool: Update to 7.7.0

### DIFF
--- a/images/bpftool/Dockerfile
+++ b/images/bpftool/Dockerfile
@@ -10,14 +10,13 @@ FROM ${TESTER_IMAGE} AS tester
 FROM ${COMPILERS_IMAGE} AS builder
 
 # renovate: datasource=github-releases depName=libbpf/bpftool
-ARG BPFTOOL_VERSION="v7.6.0"
+ARG BPFTOOL_VERSION="v7.7.0"
 WORKDIR /bpftool
 RUN git clone --recurse-submodules --branch "${BPFTOOL_VERSION}" https://github.com/libbpf/bpftool.git /bpftool
 
 RUN \
-    # From Ubuntu 24.04 builder image, libzstd must be added at the end of LIBS and LIBS_BOOTSTRAP to compile statically
-    # See https://github.com/libbpf/bpftool/issues/152
-    sed -i "s/\(LIBS = \$(LIBBPF) -lelf -lz\)/\1 -lzstd/; s/\(LIBS_BOOTSTRAP = \$(LIBBPF_BOOTSTRAP) -lelf -lz\)/\1 -lzstd/" /bpftool/src/Makefile \
+    apt-get update \
+    && apt-get install -y --no-install-recommends libssl-dev \
     && make -C src EXTRA_CFLAGS=--static BPFTOOL_VERSION="${BPFTOOL_VERSION#v}" -j "$(nproc)" \
     && strip /bpftool/src/bpftool \
     && mkdir -p /out/bin \

--- a/images/bpftool/test/spec.yaml
+++ b/images/bpftool/test/spec.yaml
@@ -16,7 +16,7 @@ commandTests:
   args: ["version"]
   expectedOutput:
   # renovate: datasource=github-releases depName=libbpf/bpftool
-  - 'bpftool v7.6.0'
+  - 'bpftool v7.7.0'
 - name: "bpftool is statically linked"
   command: "ldd"
   args: ["/usr/local/bin/bpftool"]


### PR DESCRIPTION
This PR is #472 with a couple additional fixes to account for changes between 7.6.0 and 7.7.0:

* It is no longer necessary to patch `LIBS` to add `-lzstd` since https://github.com/libbpf/bpftool/commit/67f1758bd7889bbec1ec5dab56888b19ec7212f3
* `bpftool` now links against `openssl`: "This comes at the cost of an additional build dependency to OpenSSL's development library." (see https://github.com/libbpf/bpftool/releases/tag/v7.7.0)


Validation:
```
$ docker build -t bpftool ./images/bpftool --target test --progress=plain --no-cache
[...]
#16 [test 5/5] RUN /test/bin/cst -C /test
#16 0.121 time="2026-03-23T10:42:13Z" level=info msg="File Existence Test: /usr/local/bin/bpftool"
#16 0.121 === RUN: Command Test: bpftool command is in path
#16 0.121 --- PASS
#16 0.121 duration: 953.333µs
#16 0.121 stdout: /usr/local/bin/bpftool
#16 0.121
#16 0.121 === RUN: Command Test: bpftool version
#16 0.121 --- PASS
#16 0.121 duration: 375.083µs
#16 0.121 stdout: bpftool v7.7.0
#16 0.121 using libbpf v1.7
#16 0.121 features:
#16 0.121
#16 0.121 === RUN: Command Test: bpftool is statically linked
#16 0.121 --- PASS
#16 0.121 duration: 6.999167ms
#16 0.121 stderr:       not a dynamic executable
#16 0.121
#16 0.121 === RUN: File Existence Test: /usr/local/bin/bpftool
#16 0.121 --- PASS
#16 0.121 duration: 0s
#16 0.121
#16 0.121 ===========================
#16 0.121 ========= RESULTS =========
#16 0.121 ===========================
#16 0.121 Passes:      4
#16 0.121 Failures:    0
#16 0.121 Duration:    8.327583ms
#16 0.121 Total tests: 4
#16 0.121
#16 0.121 PASS
#16 DONE 0.1s
```