### PR TITLE
images: fix `as` keyword case

### DIFF
--- a/images/checkpatch/Dockerfile
+++ b/images/checkpatch/Dockerfile
@@ -4,7 +4,7 @@
 
 ARG ALPINE_BASE_IMAGE=docker.io/library/alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
-FROM ${ALPINE_BASE_IMAGE} as builder
+FROM ${ALPINE_BASE_IMAGE} AS builder
 LABEL maintainer="maintainer@cilium.io"
 
 ARG CHECKPATCH_VERSION="v5.12"

--- a/images/compilers/Dockerfile
+++ b/images/compilers/Dockerfile
@@ -4,12 +4,12 @@
 ARG UBUNTU_IMAGE=docker.io/library/ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
 ARG TESTER_IMAGE=quay.io/cilium/image-tester:1755027438-ef4e849@sha256:ff0eb08901053e72afcfadc58e9d1736c6d1b257ffdf0779966d44e4872bfae5
 
-FROM ${UBUNTU_IMAGE} as builder
+FROM ${UBUNTU_IMAGE} AS builder
 
 COPY install-deps.sh /tmp/install-deps.sh
 RUN /tmp/install-deps.sh
 
-FROM ${TESTER_IMAGE} as test
+FROM ${TESTER_IMAGE} AS test
 COPY --from=builder / /
 COPY test /test
 ARG TARGETARCH


### PR DESCRIPTION
The `as` keyword should match the case of the `from` keyword, see https://docs.docker.com/go/dockerfile/rule/from-as-casing/

This fixes a warning reported in CI.