### PR TITLE
ci: Harden workflows with least-privilege permissions and per-PR concurrency

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -4,6 +4,14 @@ on:
   push:
     branches: [main]
 
+# Cancel superseded runs for the same PR, never cancel push-to-main builds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   generate-images-matrix:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -5,6 +5,14 @@ on:
     branches:
     - main
 
+# Cancel superseded runs for the same PR, never cancel push-to-main builds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Run static checks


### PR DESCRIPTION
Add an explicit top-level `permissions: contents: read` block to both workflows so the GITHUB_TOKEN no longer inherits the repo/org default (potentially read-write). Neither workflow need github write level permissions, image pushed are authenticated to quay.io, all that's needed from github is read-only to checkout the source.

Add a per-PR concurrency group that cancels superseded in-progress runs. The group is keyed on github.ref so each PR (and main) is isolated, and cancel-in-progress is gated on `event_name == 'pull_request'` so push-to-main release builds always run to completion.