### PR TITLE
checkpatch: Report line related issues

### DIFF
--- a/images/checkpatch/checkpatch.sh
+++ b/images/checkpatch/checkpatch.sh
@@ -29,7 +29,7 @@ ignore_list=(
     FILE_PATH_CHANGES
     FROM_SIGN_OFF_MISMATCH
     JIFFIES_COMPARISON
-    LEADING_SPACE
+    LINE_CONTINUATIONS
     MACRO_WITH_FLOW_CONTROL
     PRINTK_WITHOUT_KERN_LEVEL
     TRAILING_SEMICOLON
@@ -37,7 +37,6 @@ ignore_list=(
     VOLATILE
     # Checks
     BIT_MACRO
-    LONG_LINE_COMMENT
     # Ignore tolerance that comes by default
     C99_COMMENT_TOLERANCE
 )


### PR DESCRIPTION
Add two of the previously-ignored checks:

- Avoid spaces at start of line. Recently newer contributors have
  stumbled on this for simple function formatting. I realize that we aim
  to have spaces at start of line for multi-line DEFINE macros, but
  reviewers can peruse such failures and ignore the results. I'd prefer
  that over reviewers and contributors completely missing basic style
  guidelines for function formatting.
- Line lengths: 100 characters is plenty and it improves readability to
  have shorter wrap, ideally targeted around 80. Anyway for narrow cases
  where actual logic is easier to read with a slightly long line, we can
  ignore those on a case by case basis. Prefer to encourage shorter line
  lengths amongst contributors where we can.

Additionally, remove the line continuations report because this commonly
flags the standard multi-line comment style we use with a trailing '*/'.
